### PR TITLE
Reduce GPU peak memory in tree evaluation

### DIFF
--- a/okapi/backend/backend_interface.py
+++ b/okapi/backend/backend_interface.py
@@ -93,3 +93,19 @@ class BackendInterface:
     def arange(n, device_ref=None):
         """Create a range tensor [0, 1, ..., n-1] on same device as reference."""
         raise NotImplementedError()
+
+    @staticmethod
+    def minimum(a, b):
+        """Elementwise minimum of two tensors with identical shape."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def maximum(a, b):
+        """Elementwise maximum of two tensors with identical shape."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def no_grad():
+        """Context manager disabling autograd for the enclosed block. On backends
+        without autograd (numpy), returns a null context."""
+        raise NotImplementedError()

--- a/okapi/backend/numpy_backend.py
+++ b/okapi/backend/numpy_backend.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import numpy as np
 from loguru import logger
 
@@ -89,3 +91,15 @@ class NumpyBackend(BackendInterface):
     @staticmethod
     def arange(n, device_ref=None):
         return np.arange(n)
+
+    @staticmethod
+    def minimum(a, b):
+        return np.minimum(a, b)
+
+    @staticmethod
+    def maximum(a, b):
+        return np.maximum(a, b)
+
+    @staticmethod
+    def no_grad():
+        return nullcontext()

--- a/okapi/backend/pytorch.py
+++ b/okapi/backend/pytorch.py
@@ -97,3 +97,15 @@ class PyTorchBackend(BackendInterface):
         if device_ref is not None:
             return torch.arange(n, device=device_ref.device)
         return torch.arange(n)
+
+    @staticmethod
+    def minimum(a, b):
+        return torch.minimum(a, b)
+
+    @staticmethod
+    def maximum(a, b):
+        return torch.maximum(a, b)
+
+    @staticmethod
+    def no_grad():
+        return torch.no_grad()

--- a/okapi/fitness.py
+++ b/okapi/fitness.py
@@ -59,40 +59,43 @@ def average_precision_fitness(
     """
     from torchmetrics.classification import AveragePrecision
 
-    # Handle both Tree objects and direct tensors
-    if isinstance(tree_or_prediction, Tree):
-        evaluation = tree_or_prediction.evaluation
-    else:
-        evaluation = tree_or_prediction
+    with torch.no_grad():
+        # Handle both Tree objects and direct tensors
+        if isinstance(tree_or_prediction, Tree):
+            # predict() wraps evaluation in no_grad and toggles eager-free, so
+            # GPU peak memory is bounded during large GP populations.
+            evaluation = tree_or_prediction.predict()
+        else:
+            evaluation = tree_or_prediction
 
-    # Convert to torch.Tensor for torchmetrics compatibility
-    if not isinstance(evaluation, torch.Tensor):
-        pred = torch.tensor(B.to_numpy(evaluation))
-    else:
-        pred = evaluation
+        # Convert to torch.Tensor for torchmetrics compatibility
+        if not isinstance(evaluation, torch.Tensor):
+            pred = torch.tensor(B.to_numpy(evaluation))
+        else:
+            pred = evaluation
 
-    if not isinstance(gt, torch.Tensor):
-        gt = torch.tensor(B.to_numpy(gt))
+        if not isinstance(gt, torch.Tensor):
+            gt = torch.tensor(B.to_numpy(gt))
 
-    # Infer number of classes from ground truth
-    num_classes = _infer_num_classes(gt, task)
-    gt = gt.squeeze().int()
+        # Infer number of classes from ground truth
+        num_classes = _infer_num_classes(gt, task)
+        gt = gt.squeeze().int()
 
-    # Create metric with appropriate parameters based on task
-    if task == "multiclass":
-        metric = AveragePrecision(task=task, num_classes=num_classes)
-    elif task == "multilabel":
-        metric = AveragePrecision(task=task, num_labels=num_classes)
-    else:  # binary
-        if pred.dim() > 1:
-            if pred.shape[1] == 2:
-                pred = pred[:, 1]
-            elif pred.shape[1] == 1:
-                pred = pred.squeeze()
-        metric = AveragePrecision(task=task)
+        # Create metric with appropriate parameters based on task
+        if task == "multiclass":
+            metric = AveragePrecision(task=task, num_classes=num_classes)
+        elif task == "multilabel":
+            metric = AveragePrecision(task=task, num_labels=num_classes)
+        else:  # binary
+            if pred.dim() > 1:
+                if pred.shape[1] == 2:
+                    pred = pred[:, 1]
+                elif pred.shape[1] == 1:
+                    pred = pred.squeeze()
+            metric = AveragePrecision(task=task)
 
-    # Calculate and return the score
-    return metric(pred, gt).item()
+        # Calculate and return the score
+        return metric(pred, gt).item()
 
 
 def roc_auc_score_fitness(
@@ -119,35 +122,38 @@ def roc_auc_score_fitness(
     """
     from torchmetrics.classification import AUROC
 
-    # Handle both Tree objects and direct tensors
-    if isinstance(tree_or_prediction, Tree):
-        evaluation = tree_or_prediction.evaluation
-    else:
-        evaluation = tree_or_prediction
+    with torch.no_grad():
+        # Handle both Tree objects and direct tensors
+        if isinstance(tree_or_prediction, Tree):
+            # predict() wraps evaluation in no_grad and toggles eager-free, so
+            # GPU peak memory is bounded during large GP populations.
+            evaluation = tree_or_prediction.predict()
+        else:
+            evaluation = tree_or_prediction
 
-    # Convert to torch.Tensor for torchmetrics compatibility
-    if not isinstance(evaluation, torch.Tensor):
-        pred = torch.tensor(B.to_numpy(evaluation))
-    else:
-        pred = evaluation
+        # Convert to torch.Tensor for torchmetrics compatibility
+        if not isinstance(evaluation, torch.Tensor):
+            pred = torch.tensor(B.to_numpy(evaluation))
+        else:
+            pred = evaluation
 
-    if not isinstance(gt, torch.Tensor):
-        gt = torch.tensor(B.to_numpy(gt))
+        if not isinstance(gt, torch.Tensor):
+            gt = torch.tensor(B.to_numpy(gt))
 
-    # Infer number of classes from ground truth
-    num_classes = _infer_num_classes(gt, task)
-    gt = gt.squeeze().int()
+        # Infer number of classes from ground truth
+        num_classes = _infer_num_classes(gt, task)
+        gt = gt.squeeze().int()
 
-    # Create metric with appropriate parameters based on task
-    if task == "multiclass":
-        metric = AUROC(task=task, num_classes=num_classes)
-    elif task == "multilabel":
-        metric = AUROC(task=task, num_labels=num_classes)
-    else:  # binary
-        metric = AUROC(task=task)
+        # Create metric with appropriate parameters based on task
+        if task == "multiclass":
+            metric = AUROC(task=task, num_classes=num_classes)
+        elif task == "multilabel":
+            metric = AUROC(task=task, num_labels=num_classes)
+        else:  # binary
+            metric = AUROC(task=task)
 
-    # Calculate and return the score
-    return metric(pred, gt).item()
+        # Calculate and return the score
+        return metric(pred, gt).item()
 
 
 def accuracy_fitness(
@@ -173,35 +179,38 @@ def accuracy_fitness(
     """
     from torchmetrics.classification import Accuracy
 
-    # Handle both Tree objects and direct tensors
-    if isinstance(tree_or_prediction, Tree):
-        evaluation = tree_or_prediction.evaluation
-    else:
-        evaluation = tree_or_prediction
+    with torch.no_grad():
+        # Handle both Tree objects and direct tensors
+        if isinstance(tree_or_prediction, Tree):
+            # predict() wraps evaluation in no_grad and toggles eager-free, so
+            # GPU peak memory is bounded during large GP populations.
+            evaluation = tree_or_prediction.predict()
+        else:
+            evaluation = tree_or_prediction
 
-    # Convert to torch.Tensor for torchmetrics compatibility
-    if not isinstance(evaluation, torch.Tensor):
-        pred = torch.tensor(B.to_numpy(evaluation))
-    else:
-        pred = evaluation
+        # Convert to torch.Tensor for torchmetrics compatibility
+        if not isinstance(evaluation, torch.Tensor):
+            pred = torch.tensor(B.to_numpy(evaluation))
+        else:
+            pred = evaluation
 
-    if not isinstance(gt, torch.Tensor):
-        gt = torch.tensor(B.to_numpy(gt))
+        if not isinstance(gt, torch.Tensor):
+            gt = torch.tensor(B.to_numpy(gt))
 
-    # Infer number of classes from ground truth
-    num_classes = _infer_num_classes(gt, task)
-    gt = gt.squeeze().int()
+        # Infer number of classes from ground truth
+        num_classes = _infer_num_classes(gt, task)
+        gt = gt.squeeze().int()
 
-    # Create metric with appropriate parameters based on task
-    if task == "multiclass":
-        metric = Accuracy(task=task, num_classes=num_classes)
-    elif task == "multilabel":
-        metric = Accuracy(task=task, num_labels=num_classes)
-    else:  # binary
-        metric = Accuracy(task=task)
+        # Create metric with appropriate parameters based on task
+        if task == "multiclass":
+            metric = Accuracy(task=task, num_classes=num_classes)
+        elif task == "multilabel":
+            metric = Accuracy(task=task, num_labels=num_classes)
+        else:  # binary
+            metric = Accuracy(task=task)
 
-    # Calculate and return the score
-    return metric(pred, gt).item()
+        # Calculate and return the score
+        return metric(pred, gt).item()
 
 
 # Convenience partial functions for different classification tasks

--- a/okapi/node.py
+++ b/okapi/node.py
@@ -24,6 +24,13 @@ class Node:
         children (List[Node]): A list of references to a children nodes.
     """
 
+    # When True, intermediate ValueNode.evaluation results are freed eagerly during
+    # tree evaluation (inside OperatorNode._concat / streaming reductions) as soon
+    # as a parent consumes them. Toggled by Tree.predict() via try/finally so that
+    # direct calls to Node.calculate() keep the older "caches remain for inspection"
+    # behavior used by existing tests and debugging workflows.
+    _EAGER_FREE_EVALS: bool = False
+
     def __init__(self, children: Optional[Sequence["Node"]] = None):
         """
         Create a node
@@ -211,12 +218,37 @@ class OperatorNode(Node):
     def _concat(self):
         assert self.parent is not None, "OperatorNode must have a parent to be calculated"
         parent: ValueNode = cast(ValueNode, self.parent)
-        parent_eval = parent.evaluation if parent.evaluation is not None else parent.value
+        used_parent_eval = parent.evaluation is not None
+        parent_eval = parent.evaluation if used_parent_eval else parent.value
         logger.trace(f"Concatenating parent and {len(self.children)} children tensors")
-        return B.concat(
+        concat = B.concat(
             [B.unsqueeze(parent_eval, axis=0)] + [B.unsqueeze(child.calculate(), axis=0) for child in self.children],
             axis=0,
         )
+        if Node._EAGER_FREE_EVALS:
+            if used_parent_eval:
+                parent.evaluation = None
+            for child in self.children:
+                if isinstance(child, ValueNode):
+                    child.evaluation = None
+        return concat
+
+    def _stream_inputs(self):
+        """Yield parent_eval and each child's evaluation one at a time for
+        streaming reductions. With _EAGER_FREE_EVALS on, cached evaluations are
+        nulled immediately after being yielded so the consumer's `+=` / min /
+        max accumulation can reclaim the underlying GPU tensor before moving
+        on to the next child. parent.value (base tensor) is never touched."""
+        assert self.parent is not None, "OperatorNode must have a parent to be calculated"
+        parent: ValueNode = cast(ValueNode, self.parent)
+        used_parent_eval = parent.evaluation is not None
+        yield parent.evaluation if used_parent_eval else parent.value
+        if Node._EAGER_FREE_EVALS and used_parent_eval:
+            parent.evaluation = None
+        for child in self.children:
+            yield child.calculate()
+            if Node._EAGER_FREE_EVALS and isinstance(child, ValueNode):
+                child.evaluation = None
 
     @staticmethod
     def create_node(children):
@@ -261,6 +293,17 @@ class MeanNode(OperatorNode):
     def op(self, x):
         return B.mean(x, axis=0)
 
+    def calculate(self):
+        running_sum = None
+        count = 0
+        for tensor in self._stream_inputs():
+            if running_sum is None:
+                running_sum = B.clone(tensor)
+            else:
+                running_sum += tensor
+            count += 1
+        return PF(running_sum / count)
+
     @staticmethod
     def create_node(children):  # TODO: it could be derived from simple vs parametrized OperatorNode
         return MeanNode(children)
@@ -293,6 +336,18 @@ class WeightedMeanNode(OperatorNode):
         x = x * w
         x = B.sum(x, axis=0)
         return x
+
+    def calculate(self):
+        self._weight_length_assertion()
+        self._weight_sum_assertion()
+        weights = self._weights
+        running_sum = None
+        for i, tensor in enumerate(self._stream_inputs()):
+            if running_sum is None:
+                running_sum = tensor * weights[i]
+            else:
+                running_sum += tensor * weights[i]
+        return PF(running_sum)
 
     def copy(self):
         return WeightedMeanNode([], [x for x in self._weights])  # this needs to be rethought
@@ -338,11 +393,6 @@ class WeightedMeanNode(OperatorNode):
     def replace_child(self, child, replacement_node):
         super().replace_child(child, replacement_node)
         self._weight_length_assertion()
-
-    def calculate(self):
-        self._weight_length_assertion()
-        self._weight_sum_assertion()
-        return super().calculate()
 
     def __str__(self) -> str:
         return f"WeightedMeanNode with weights: {B.to_numpy(B.tensor(self._weights)).round(2)}"
@@ -452,6 +502,15 @@ class MaxNode(OperatorNode):
     def op(self, x):
         return B.max(x, axis=0)
 
+    def calculate(self):
+        result = None
+        for tensor in self._stream_inputs():
+            if result is None:
+                result = B.clone(tensor)
+            else:
+                result = B.maximum(result, tensor)
+        return PF(result)
+
     def adjust_params(self):
         return
 
@@ -482,6 +541,15 @@ class MinNode(OperatorNode):
 
     def op(self, x):
         return B.min(x, axis=0)
+
+    def calculate(self):
+        result = None
+        for tensor in self._stream_inputs():
+            if result is None:
+                result = B.clone(tensor)
+            else:
+                result = B.minimum(result, tensor)
+        return PF(result)
 
     def adjust_params(self):
         return

--- a/okapi/tree.py
+++ b/okapi/tree.py
@@ -157,14 +157,25 @@ class Tree:
             fitness = objective_function(prediction, ground_truth)
         """
         logger.debug("Computing prediction with cache management")
-        result = self.evaluation
-        result_copy = B.clone(result)
+        # Scoped eager-free: free per-node .evaluation caches as each parent op
+        # consumes them. try/finally so .calculate() elsewhere keeps the "caches
+        # remain after eval" behavior used by tests and debugging.
+        prev_flag = Node._EAGER_FREE_EVALS
+        Node._EAGER_FREE_EVALS = True
+        try:
+            with B.no_grad():
+                result = self.evaluation
+        finally:
+            Node._EAGER_FREE_EVALS = prev_flag
 
         if clear_cache:
+            # Tree no longer holds a ref to result; caller's alias is unique.
             self._clean_evals()
             logger.trace("Evaluation caches cleared")
-
-        return result_copy
+            return result
+        # Cache kept → result is aliased by self.root.evaluation. Return a clone
+        # so the caller cannot mutate internal state through it.
+        return B.clone(result)
 
     def copy(self):
         """

--- a/test/test_memory_optimizations.py
+++ b/test/test_memory_optimizations.py
@@ -1,0 +1,398 @@
+"""Tests for GPU memory optimizations:
+
+1. `torch.no_grad()` wrapping in evaluation path
+2. Eager child ValueNode.evaluation freeing during _concat
+3. Streaming reductions bypassing the concat buffer for Mean/WeightedMean/Min/Max
+"""
+from contextlib import nullcontext
+from unittest import mock
+
+import numpy as np
+import pytest
+import torch
+
+from okapi.backend.backend import Backend
+from okapi.backend.numpy_backend import NumpyBackend
+from okapi.backend.pytorch import PyTorchBackend
+from okapi.fitness import (
+    accuracy_fitness,
+    average_precision_fitness,
+    roc_auc_score_fitness,
+)
+from okapi.node import (
+    CloseThresholdNode,
+    MaxNode,
+    MeanNode,
+    MinNode,
+    Node,
+    OperatorNode,
+    ValueNode,
+    WeightedMeanNode,
+)
+from okapi.tree import Tree
+
+
+# ---------------- shared fixtures ----------------
+
+
+@pytest.fixture
+def restore_backend():
+    """Restore the original backend after a test that switches it."""
+    original = Backend.get_backend()
+    yield
+    Backend._current_backend = original
+
+
+@pytest.fixture
+def restore_eager_free_flag():
+    """Restore Node._EAGER_FREE_EVALS after a test that toggles it."""
+    original = getattr(Node, "_EAGER_FREE_EVALS", False)
+    yield
+    Node._EAGER_FREE_EVALS = original
+
+
+def _make_mean_tree_torch(requires_grad: bool = False):
+    """A -> MeanNode -> [C, D] using torch tensors."""
+    a = torch.tensor([[0.2, 0.2], [0.3, 0.3]], requires_grad=requires_grad)
+    c = torch.tensor([[0.3, 0.3], [0.4, 0.4]], requires_grad=requires_grad)
+    d = torch.tensor([[0.4, 0.4], [0.5, 0.5]], requires_grad=requires_grad)
+
+    A = ValueNode(None, a, 1)
+    C = ValueNode(None, c, 2)
+    D = ValueNode(None, d, 3)
+    B_ = MeanNode([C, D])
+    A.add_child(B_)
+    return {"A": A, "B": B_, "C": C, "D": D, "a": a, "c": c, "d": d}
+
+
+def _make_mean_tree_numpy():
+    a = np.array([[2.0, 2.0], [3.0, 3.0]])
+    c = np.array([[3.0, 3.0], [4.0, 4.0]])
+    d = np.array([[4.0, 4.0], [5.0, 5.0]])
+
+    A = ValueNode(None, a, 1)
+    C = ValueNode(None, c, 2)
+    D = ValueNode(None, d, 3)
+    B_ = MeanNode([C, D])
+    A.add_child(B_)
+    return {"A": A, "B": B_, "C": C, "D": D}
+
+
+# ============================================================
+# Fix #1 — torch.no_grad() in evaluation path
+# ============================================================
+
+
+class TestNoGradWrapping:
+    def test_tree_predict_returns_detached_tensor_with_grad_input(self, restore_backend):
+        """If input ValueNodes carry requires_grad, tree.predict() output must be
+        detached (grad_fn is None). We respect the user's requires_grad but do not
+        build a graph through our operations."""
+        Backend.set_backend("pytorch")
+        nodes = _make_mean_tree_torch(requires_grad=True)
+        tree = Tree.create_tree_from_root(nodes["A"])
+
+        pred = tree.predict()
+
+        assert pred.grad_fn is None, (
+            "tree.predict() must return a tensor without a grad_fn; "
+            "found one, meaning autograd is building a graph through evaluation"
+        )
+
+    def test_tree_predict_preserves_user_requires_grad_on_value_nodes(self, restore_backend):
+        """The user's input tensors must be left untouched — same requires_grad as before."""
+        Backend.set_backend("pytorch")
+        nodes = _make_mean_tree_torch(requires_grad=True)
+        tree = Tree.create_tree_from_root(nodes["A"])
+
+        _ = tree.predict()
+
+        assert nodes["a"].requires_grad is True
+        assert nodes["c"].requires_grad is True
+        assert nodes["d"].requires_grad is True
+
+    def test_tree_predict_without_grad_inputs_still_works(self, restore_backend):
+        """Sanity: no_grad wrapping does not break the common case of plain tensors."""
+        Backend.set_backend("pytorch")
+        nodes = _make_mean_tree_torch(requires_grad=False)
+        tree = Tree.create_tree_from_root(nodes["A"])
+
+        pred = tree.predict()
+
+        expected = np.array([[0.3, 0.3], [0.4, 0.4]])
+        np.testing.assert_allclose(pred.detach().cpu().numpy(), expected)
+
+    @pytest.mark.parametrize(
+        "fitness_fn",
+        [average_precision_fitness, roc_auc_score_fitness, accuracy_fitness],
+    )
+    def test_fitness_functions_do_not_build_graph(self, restore_backend, fitness_fn):
+        """Each fitness function, when called on a Tree whose leaf tensors require
+        grad, must run under no_grad so tree.predict() inside returns a detached
+        tensor and the returned score is a plain float."""
+        Backend.set_backend("pytorch")
+        nodes = _make_mean_tree_torch(requires_grad=True)
+        tree = Tree.create_tree_from_root(nodes["A"])
+        gt = torch.tensor([[1, 0], [1, 1]])
+
+        observed = {}
+        original_predict = Tree.predict
+
+        def spy_predict(self, *a, **kw):
+            out = original_predict(self, *a, **kw)
+            observed["grad_fn"] = out.grad_fn
+            return out
+
+        with mock.patch.object(Tree, "predict", spy_predict):
+            score = fitness_fn(tree, gt, task="multilabel")
+
+        assert isinstance(score, float)
+        assert observed["grad_fn"] is None
+
+
+# ============================================================
+# Fix #2 — Eager child ValueNode.evaluation freeing
+# ============================================================
+
+
+class TestEagerEvalFreeing:
+    def test_flag_defaults_to_false(self):
+        assert getattr(Node, "_EAGER_FREE_EVALS", False) is False
+
+    def test_flag_off_preserves_child_evaluations(self):
+        """With the flag off, existing behavior: after parent's calculate(), children's
+        .evaluation is set (for inspection / test compatibility)."""
+        nodes = _make_mean_tree_numpy()
+        nodes["A"].calculate()
+
+        assert nodes["C"].evaluation is not None
+        assert nodes["D"].evaluation is not None
+
+    def test_flag_on_nulls_child_evaluations_after_concat(self, restore_eager_free_flag):
+        """With flag on, _concat eagerly frees each child's .evaluation as soon as
+        the concat buffer has copied them in."""
+        Node._EAGER_FREE_EVALS = True
+        nodes = _make_mean_tree_numpy()
+        nodes["A"].calculate()
+
+        assert nodes["C"].evaluation is None
+        assert nodes["D"].evaluation is None
+
+    def test_flag_on_never_touches_value_of_base_value_node(self, restore_eager_free_flag):
+        """_EAGER_FREE_EVALS must not touch ValueNode.value (the base tensor)."""
+        Node._EAGER_FREE_EVALS = True
+        nodes = _make_mean_tree_numpy()
+        expected_c_value = nodes["C"].value.copy()
+        expected_d_value = nodes["D"].value.copy()
+
+        nodes["A"].calculate()
+
+        np.testing.assert_array_equal(nodes["C"].value, expected_c_value)
+        np.testing.assert_array_equal(nodes["D"].value, expected_d_value)
+
+    def test_flag_on_nulls_parent_evaluation_when_used(self, restore_eager_free_flag):
+        """If parent.evaluation was used by _concat (not parent.value), it should be
+        nulled after concat. parent.value must remain intact."""
+        Node._EAGER_FREE_EVALS = True
+        a = np.array([[2.0, 2.0], [3.0, 3.0]])
+        c = np.array([[3.0, 3.0], [4.0, 4.0]])
+        d = np.array([[4.0, 4.0], [5.0, 5.0]])
+
+        parent = ValueNode(None, a, 1)
+        C = ValueNode(None, c, 2)
+        D = ValueNode(None, d, 3)
+        op = OperatorNode([C, D])
+        parent.add_child(op)
+
+        # Pre-populate parent.evaluation so _concat uses it instead of parent.value
+        parent.evaluation = np.array([[1.0, 1.0], [1.0, 1.0]])
+
+        _ = op._concat()
+
+        assert parent.evaluation is None, "parent.evaluation should be freed after concat used it"
+        np.testing.assert_array_equal(parent.value, a), "parent.value must be untouched"
+
+    def test_tree_predict_activates_eager_free_during_traversal(self, restore_backend):
+        """Tree.predict(clear_cache=True) must enable the flag DURING traversal so
+        peak memory is reduced (not only at the end via _clean_evals). We probe
+        with a ThresholdNode tree since reducing ops now stream and bypass
+        _concat — ThresholdNode still uses _concat, so it's the reliable probe."""
+        Backend.set_backend("pytorch")
+        a = torch.tensor([[0.2, 0.2], [0.3, 0.3]])
+        c = torch.tensor([[0.3, 0.3], [0.4, 0.4]])
+        d = torch.tensor([[0.4, 0.4], [0.5, 0.5]])
+        A = ValueNode(None, a, 1)
+        C = ValueNode(None, c, 2)
+        D = ValueNode(None, d, 3)
+        op = CloseThresholdNode([C, D], 0.4)
+        A.add_child(op)
+        tree = Tree.create_tree_from_root(A)
+
+        observed = {}
+        original_concat = OperatorNode._concat
+
+        def spy_concat(self):
+            # Capture flag state DURING _concat (before post-traversal cleanup)
+            observed.setdefault("flag_during_concat", Node._EAGER_FREE_EVALS)
+            return original_concat(self)
+
+        with mock.patch.object(OperatorNode, "_concat", spy_concat):
+            _ = tree.predict(clear_cache=True)
+
+        assert observed.get("flag_during_concat") is True, (
+            "Node._EAGER_FREE_EVALS must be True while _concat runs inside tree.predict(), "
+            "so intermediate evals are freed eagerly"
+        )
+        # Flag must be restored afterwards (try/finally semantics)
+        assert Node._EAGER_FREE_EVALS is False
+
+
+# ============================================================
+# Fix #3 — Streaming reductions bypass the concat buffer
+# ============================================================
+
+
+class TestStreamingReductions:
+    @staticmethod
+    def _concat_call_counter():
+        """Returns (counter, patched_fn) — patched_fn is a regular function so it
+        binds `self` via the descriptor protocol, unlike a raw Mock."""
+        counter = {"n": 0}
+        original = OperatorNode._concat
+
+        def counting(self):
+            counter["n"] += 1
+            return original(self)
+
+        return counter, counting
+
+    @pytest.mark.parametrize(
+        "op_cls, weights",
+        [
+            (MeanNode, None),
+            (MinNode, None),
+            (MaxNode, None),
+            (WeightedMeanNode, [0.3, 0.2, 0.5]),
+        ],
+    )
+    def test_reducing_op_does_not_call_concat(self, op_cls, weights):
+        """Reducing ops (mean/weighted_mean/min/max) must compute via a streaming
+        path, bypassing _concat which would materialize an (N+1, ...) buffer."""
+        a = np.array([[2.0, 2.0], [3.0, 3.0]])
+        c = np.array([[3.0, 3.0], [4.0, 4.0]])
+        d = np.array([[4.0, 4.0], [5.0, 5.0]])
+
+        A = ValueNode(None, a, 1)
+        C = ValueNode(None, c, 2)
+        D = ValueNode(None, d, 3)
+        if weights is not None:
+            op = op_cls([C, D], weights)
+        else:
+            op = op_cls([C, D])
+        A.add_child(op)
+
+        counter, patched = self._concat_call_counter()
+        with mock.patch.object(OperatorNode, "_concat", patched):
+            A.calculate()
+
+        assert counter["n"] == 0, (
+            f"{op_cls.__name__}.calculate() must not call _concat (streaming path expected); "
+            f"got {counter['n']} call(s)"
+        )
+
+    def test_threshold_still_uses_concat(self):
+        """ThresholdNode needs the full stack for argmin/argmax, so it keeps the
+        concat path."""
+        a = np.array([[0.2, 0.2], [0.3, 0.3]])
+        c = np.array([[0.3, 0.3], [0.4, 0.4]])
+        d = np.array([[0.4, 0.4], [0.5, 0.5]])
+
+        A = ValueNode(None, a, 1)
+        C = ValueNode(None, c, 2)
+        D = ValueNode(None, d, 3)
+        op = CloseThresholdNode([C, D], 0.4)
+        A.add_child(op)
+
+        counter, patched = self._concat_call_counter()
+        with mock.patch.object(OperatorNode, "_concat", patched):
+            A.calculate()
+
+        assert counter["n"] >= 1, "ThresholdNode must still use _concat"
+
+    # Numerical correctness is already covered by test_node.py (test_mean,
+    # test_weighted_mean, test_min_tree, test_max_tree, test_weighted_mean_child_*)
+    # Those tests hit the same calculate() paths and act as regressions. We add
+    # a torch-backend correctness spot-check here to confirm parity across backends.
+    def test_mean_streaming_torch_matches_numpy(self, restore_backend):
+        Backend.set_backend("pytorch")
+        t = _make_mean_tree_torch(requires_grad=False)
+        tree = Tree.create_tree_from_root(t["A"])
+        pred_torch = tree.predict().detach().cpu().numpy()
+
+        Backend.set_backend("numpy")
+        n = _make_mean_tree_numpy()
+        # Scale numpy fixture values to match torch fixture values
+        n["A"].value = np.array([[0.2, 0.2], [0.3, 0.3]])
+        n["C"].value = np.array([[0.3, 0.3], [0.4, 0.4]])
+        n["D"].value = np.array([[0.4, 0.4], [0.5, 0.5]])
+        n["A"].evaluation = n["C"].evaluation = n["D"].evaluation = None
+        tree_n = Tree.create_tree_from_root(n["A"])
+        pred_numpy = tree_n.predict()
+
+        np.testing.assert_allclose(pred_torch, pred_numpy, rtol=1e-6)
+
+    def test_min_streaming_correctness(self):
+        a = np.array([[2.0, 2.0], [3.0, 3.0]])
+        c = np.array([[3.0, 3.0], [4.0, 4.0]])
+        d = np.array([[4.0, 4.0], [5.0, 5.0]])
+        A = ValueNode(None, a, 1)
+        op = MinNode([ValueNode(None, c, 2), ValueNode(None, d, 3)])
+        A.add_child(op)
+        A.calculate()
+        np.testing.assert_array_equal(A.evaluation, np.array([[2.0, 2.0], [3.0, 3.0]]))
+
+    def test_max_streaming_correctness(self):
+        a = np.array([[2.0, 2.0], [3.0, 3.0]])
+        c = np.array([[3.0, 3.0], [4.0, 4.0]])
+        d = np.array([[4.0, 4.0], [5.0, 5.0]])
+        A = ValueNode(None, a, 1)
+        op = MaxNode([ValueNode(None, c, 2), ValueNode(None, d, 3)])
+        A.add_child(op)
+        A.calculate()
+        np.testing.assert_array_equal(A.evaluation, np.array([[4.0, 4.0], [5.0, 5.0]]))
+
+
+# ============================================================
+# Backend additions: minimum / maximum / no_grad
+# ============================================================
+
+
+class TestBackendAdditions:
+    @pytest.mark.parametrize("B", [NumpyBackend, PyTorchBackend])
+    def test_minimum_elementwise(self, B):
+        a = B.tensor([[1.0, 4.0], [3.0, 2.0]])
+        b = B.tensor([[2.0, 3.0], [3.0, 1.0]])
+        result = B.to_numpy(B.minimum(a, b))
+        np.testing.assert_array_equal(result, np.array([[1.0, 3.0], [3.0, 1.0]]))
+
+    @pytest.mark.parametrize("B", [NumpyBackend, PyTorchBackend])
+    def test_maximum_elementwise(self, B):
+        a = B.tensor([[1.0, 4.0], [3.0, 2.0]])
+        b = B.tensor([[2.0, 3.0], [3.0, 1.0]])
+        result = B.to_numpy(B.maximum(a, b))
+        np.testing.assert_array_equal(result, np.array([[2.0, 4.0], [3.0, 2.0]]))
+
+    def test_numpy_no_grad_is_nullcontext(self):
+        ctx = NumpyBackend.no_grad()
+        # Should be a context manager that does nothing
+        with ctx:
+            assert True
+
+    def test_pytorch_no_grad_disables_autograd(self):
+        x = torch.tensor([1.0, 2.0], requires_grad=True)
+        with PyTorchBackend.no_grad():
+            y = x * 2
+            assert y.grad_fn is None
+        # Outside the context, autograd is back on
+        z = x * 2
+        assert z.grad_fn is not None


### PR DESCRIPTION
Three layered fixes to resolve OOM on large populations / segmentation-sized tensors:

1. torch.no_grad() in the evaluation path. Tree.predict() and fitness functions now run under B.no_grad() so we don't build an autograd graph through mean/sum/concat/unsqueeze/reshape even if loaded tensors carry requires_grad. The user's requires_grad on loaded tensors is preserved (we never force-detach).

2. Eager freeing of intermediate ValueNode.evaluation caches. A scoped class-level flag Node._EAGER_FREE_EVALS (toggled by Tree.predict via try/finally) drops each child's cached evaluation the moment the parent op has consumed it. ValueNode.value (base tensor) is never touched. Peak drops from O(#value_nodes * tensor) to O(depth * tensor).

3. Streaming reductions for MeanNode, WeightedMeanNode, MinNode, MaxNode. These ops no longer materialize the (N+1, ...) concat buffer; they accumulate running sum / elementwise min-max across a generator. ThresholdNode keeps the concat path (argmin/argmax needs the full stack).

Backend additions: BackendInterface.{minimum, maximum, no_grad} with PyTorch and NumPy (nullcontext) implementations.

Covered by 26 tests in test/test_memory_optimizations.py; full suite 192/192.