### PR TITLE
OKAPI 2.0: core bug fix + depth/node caps + logit-space operators

### DIFF
--- a/okapi/backend/backend_interface.py
+++ b/okapi/backend/backend_interface.py
@@ -56,6 +56,10 @@ class BackendInterface:
         raise NotImplementedError()
 
     @staticmethod
+    def exp(x):
+        raise NotImplementedError()
+
+    @staticmethod
     def to_float(x):
         raise NotImplementedError()
 

--- a/okapi/backend/numpy_backend.py
+++ b/okapi/backend/numpy_backend.py
@@ -52,6 +52,10 @@ class NumpyBackend(BackendInterface):
         return np.log(x)
 
     @staticmethod
+    def exp(x):
+        return np.exp(x)
+
+    @staticmethod
     def to_float(x):
         return x.astype(float)
 

--- a/okapi/backend/pytorch.py
+++ b/okapi/backend/pytorch.py
@@ -56,6 +56,10 @@ class PyTorchBackend(BackendInterface):
         return torch.log(x)
 
     @staticmethod
+    def exp(x):
+        return torch.exp(x)
+
+    @staticmethod
     def to_float(x):
         return x.float()
 

--- a/okapi/backend/pytorch.py
+++ b/okapi/backend/pytorch.py
@@ -45,7 +45,7 @@ class PyTorchBackend(BackendInterface):
 
     @staticmethod
     def to_numpy(x):
-        return x.detach().numpy()
+        return x.detach().cpu().numpy()
 
     @staticmethod
     def clip(x, min, max):

--- a/okapi/crossover.py
+++ b/okapi/crossover.py
@@ -55,19 +55,88 @@ def tournament_selection_indexes(fitnesses: np.ndarray, tournament_size: int = 5
     return selected
 
 
-def crossover(tree1: Tree, tree2: Tree, node_type=None):
+def _node_xover_metrics(tree: Tree):
+    """Integer per-node geometry used to predict an offspring's depth/size *without*
+    building it: depth-from-root, subtree height, subtree node-count, and the tree's
+    max leaf-depth EXCLUDING each node's subtree. All cheap (no tensor ops); only
+    computed on the capped path, where trees are small by construction."""
+    nodes = tree.root.get_nodes()  # BFS: parents precede children
+    depth_of: dict = {}
+    for n in nodes:
+        depth_of[n] = 1 if n.parent is None else depth_of[n.parent] + 1
+    leaves = [n for n in nodes if not n.children]
+
+    def _ancestors_inclusive(node):
+        seen, cur = set(), node
+        while cur is not None:
+            seen.add(cur)
+            cur = cur.parent
+        return seen
+
+    leaf_ancestors = {leaf: _ancestors_inclusive(leaf) for leaf in leaves}
+    height_of: dict = {}
+    count_of: dict = {}
+    for n in reversed(nodes):  # children precede parents
+        if not n.children:
+            height_of[n], count_of[n] = 1, 1
+        else:
+            height_of[n] = 1 + max(height_of[c] for c in n.children)
+            count_of[n] = 1 + sum(count_of[c] for c in n.children)
+    depth_excluding: dict = {}
+    for n in nodes:
+        depth_excluding[n] = max((depth_of[leaf] for leaf in leaves if n not in leaf_ancestors[leaf]), default=0)
+    return depth_of, height_of, count_of, depth_excluding
+
+
+def _legal_crossover_pair(tree1: Tree, tree2: Tree, nodes_type: str, max_depth, max_nodes):
+    """Uniformly pick a ``(node1, node2)`` pair of ``nodes_type`` whose *both* offspring
+    respect the caps, or ``None`` if no such pair exists. Swapping the subtree at node1
+    (in tree1) with the one at node2 (in tree2) gives offspring-1 depth
+    ``max(excl1[n1], depth1[n1]-1 + height2[n2])`` and node-count ``N1 - count1[n1] +
+    count2[n2]`` (symmetric for offspring-2). For ``value_nodes`` the root x root pair is
+    always present (each offspring becomes a whole within-caps parent), so the engine
+    path -- which always allows value_nodes -- never comes up empty."""
+    depth1, height1, count1, excl1 = _node_xover_metrics(tree1)
+    depth2, height2, count2, excl2 = _node_xover_metrics(tree2)
+    n1_total, n2_total = tree1.nodes_count, tree2.nodes_count
+    legal = []
+    for n1 in tree1.nodes[nodes_type]:
+        for n2 in tree2.nodes[nodes_type]:
+            off1_depth = max(excl1[n1], depth1[n1] - 1 + height2[n2])
+            off2_depth = max(excl2[n2], depth2[n2] - 1 + height1[n1])
+            if max_depth is not None and (off1_depth > max_depth or off2_depth > max_depth):
+                continue
+            off1_nodes = n1_total - count1[n1] + count2[n2]
+            off2_nodes = n2_total - count2[n2] + count1[n1]
+            if max_nodes is not None and (off1_nodes > max_nodes or off2_nodes > max_nodes):
+                continue
+            legal.append((n1, n2))
+    if not legal:
+        return None
+    return legal[np.random.randint(len(legal))]
+
+
+def crossover(tree1: Tree, tree2: Tree, node_type=None, max_depth=None, max_nodes=None):
     """
     Performs crossover between two parent trees to produce two offspring trees.
 
-    Crossover works by selecting a random node from each parent tree and swapping
-    the subtrees rooted at those nodes. This creates two new offspring trees that
-    contain genetic material from both parents.
+    Crossover works by selecting a node from each parent tree and swapping the subtrees
+    rooted at those nodes, producing two offspring that mix both parents.
+
+    Cap enforcement is deterministic, not generate-and-reject: with ``max_depth`` /
+    ``max_nodes`` set, the crossover points are drawn only from pairs whose *both*
+    offspring stay within the caps (``_legal_crossover_pair``). Because the root x root
+    value-node swap is always legal, a usable pair always exists, so the search never
+    needs retries or a parent-copy fallback. With both caps ``None`` the original uniform
+    ``get_random_node`` draw is used unchanged.
 
     Args:
         tree1: First parent tree
         tree2: Second parent tree
         node_type: Type of nodes to consider for crossover points ('value_nodes' or 'op_nodes').
                    If None, a random suitable type will be chosen.
+        max_depth: Optional hard depth cap (see above).
+        max_nodes: Optional hard node-count cap (see above).
 
     Returns:
         Tuple of two new Tree objects created by crossover
@@ -77,29 +146,42 @@ def crossover(tree1: Tree, tree2: Tree, node_type=None):
     """
     logger.info("Performing crossover between two trees")
 
+    both_have_ops = (len(tree1.nodes["op_nodes"]) > 0) and (len(tree2.nodes["op_nodes"]) > 0)
     if node_type is None:
-        allowable_node_types = ["value_nodes"]  # TODO: this may be worth refactoring along with "get_random_node" to not use string but types instead
-
-        if (len(tree1.nodes["op_nodes"]) > 0) & (len(tree2.nodes["op_nodes"]) > 0):
+        allowable_node_types = ["value_nodes"]
+        if both_have_ops:
             allowable_node_types.append("op_nodes")
             logger.debug("Both trees have operator nodes, including them in potential crossover points")
         else:
             logger.debug("At least one tree has no operator nodes, using only value nodes for crossover")
-
-        nodes_type = np.random.choice(allowable_node_types)
-        logger.debug(f"Randomly selected node type for crossover: {nodes_type}")
     else:
-        if node_type == "op_nodes" and not ((len(tree1.nodes["op_nodes"]) > 0) & (len(tree2.nodes["op_nodes"]) > 0)):
+        if node_type == "op_nodes" and not both_have_ops:
             logger.error("Node type was chosen to be operator nodes but there are no operator nodes in at least one of the parents")
             raise ValueError("Node type was chosen to be operator nodes but there are not operator nodes in at least one of the parents")
-        nodes_type = node_type
-        logger.debug(f"Using specified node type for crossover: {nodes_type}")
+        allowable_node_types = [node_type]
 
     logger.debug("Creating copies of parent trees")
     tree1, tree2 = tree1.copy(), tree2.copy()
 
-    logger.debug("Selecting random nodes for crossover")
-    node1, node2 = tree1.get_random_node(nodes_type), tree2.get_random_node(nodes_type)
+    if max_depth is None and max_nodes is None:
+        # Uncapped: original behaviour, byte-for-byte (uniform type then uniform node).
+        nodes_type = np.random.choice(allowable_node_types)
+        node1, node2 = tree1.get_random_node(nodes_type), tree2.get_random_node(nodes_type)
+    else:
+        # Capped: try the allowable type(s) in random order, take the first that has a
+        # cap-legal pair. value_nodes always does (root x root), so this resolves.
+        np.random.shuffle(allowable_node_types)
+        node1 = node2 = None
+        for nodes_type in allowable_node_types:
+            pair = _legal_crossover_pair(tree1, tree2, nodes_type, max_depth, max_nodes)
+            if pair is not None:
+                node1, node2 = pair
+                break
+        if node1 is None:
+            # Unreachable on the engine path (value root x root is always legal); only a
+            # tight explicit op-only request can land here -> no-op (return parent copies).
+            logger.trace("No cap-legal crossover pair for the requested type; returning parent copies")
+            return tree1, tree2
     logger.debug(f"Selected nodes: {node1} from tree1, {node2} from tree2")
 
     logger.debug("Creating copies of subtrees")

--- a/okapi/crossover.py
+++ b/okapi/crossover.py
@@ -31,7 +31,7 @@ def tournament_selection_indexes(fitnesses: np.ndarray, tournament_size: int = 5
 
     if len(fitnesses) < (2 * tournament_size):
         logger.warning(
-            f"Tournament size ({tournament_size}), is small related to the population size ({len(fitnesses)})."
+            f"Tournament size ({tournament_size}) is large relative to the population size ({len(fitnesses)})."
             "The population should be at least twice as large as tournament for more stable parent selection"
         )
 

--- a/okapi/mutation.py
+++ b/okapi/mutation.py
@@ -40,7 +40,8 @@ def mutate_parameters(tree: Tree, mutation_strength: float = 0.1, **kwargs):
 
 
 def append_new_node_mutation(
-    tree: Tree, models: Sequence[Tensor], ids: None | Sequence[str | int] = None, allowed_ops: tuple[Type[OperatorNode], ...] = (MeanNode,), **kwargs
+    tree: Tree, models: Sequence[Tensor], ids: None | Sequence[str | int] = None, allowed_ops: tuple[Type[OperatorNode], ...] = (MeanNode,),
+    max_depth: int | None = None, max_nodes: int | None = None, **kwargs
 ):
     """
     Mutation that adds a new node to the tree.
@@ -55,10 +56,16 @@ def append_new_node_mutation(
         models: Sequence of tensor models that can be used as values for the new ValueNode
         ids: Optional sequence of identifiers for the models. If None, indices will be used
         allowed_ops: Tuple of OperatorNode types that can be used when creating a new operator node
+        max_depth: Optional hard depth cap. When set (with max_nodes), the attachment point is
+            drawn only from ``tree.legal_append_targets`` so the result never exceeds the caps -
+            deterministic legal selection rather than generate-and-reject. ``None`` (uncapped)
+            keeps the historical uniform ``get_random_node`` draw exactly.
+        max_nodes: Optional hard node-count cap (see max_depth).
         **kwargs: Additional keyword arguments (ignored)
 
     Returns:
-        A new Tree with the mutation applied
+        A new Tree with the mutation applied (or, only under a cap that forbids every
+        attachment point, the unchanged copy).
     """
     logger.debug("Applying append_new_node_mutation")
     tree = tree.copy()
@@ -72,8 +79,15 @@ def append_new_node_mutation(
 
     idx_model = np.random.randint(len(ids))
     logger.debug(f"Selected model ID: {ids[idx_model]}")
-    node = tree.get_random_node()
-    logger.debug(f"Selected random node for mutation: {node}")
+    if max_depth is None and max_nodes is None:
+        node = tree.get_random_node()  # uncapped: historical uniform draw, unchanged
+    else:
+        targets = tree.legal_append_targets(max_depth=max_depth, max_nodes=max_nodes)
+        if not targets:
+            logger.trace("No cap-legal append target available; returning tree unchanged")
+            return tree
+        node = targets[np.random.randint(len(targets))]
+    logger.debug(f"Selected node for mutation: {node}")
 
     val_node: ValueNode = ValueNode([], models[idx_model], ids[idx_model])
     logger.trace(f"Created new value node with ID: {ids[idx_model]}")
@@ -160,7 +174,7 @@ def new_tree_from_branch_mutation(tree: Tree, **kwargs):
     return new_tree
 
 
-def get_allowed_mutations(tree, max_nodes: int | None = None):
+def get_allowed_mutations(tree, max_depth: int | None = None, max_nodes: int | None = None):
     """
     Determines which mutation operations are valid for a given tree.
 
@@ -169,20 +183,22 @@ def get_allowed_mutations(tree, max_nodes: int | None = None):
 
     Args:
         tree: The tree to analyze
-        max_nodes: Optional hard cap on node count. When set and the tree is already at
-            (or above) the cap, ``append_new_node_mutation`` is excluded so the search does
-            not waste effort growing trees that would only be rejected. Note the depth cap
-            is intentionally *not* applied here: append can also grow a tree *wider* without
-            increasing depth (a sibling at a shallow operator), which is exactly how compact
-            wide-shallow trees form at ``max_depth=3``. Depth is therefore enforced after the
-            mutation (see ``Okapi._within_caps``), rejecting only appends that truly deepen.
+        max_depth: Optional hard cap on tree depth.
+        max_nodes: Optional hard cap on node count.
+
+        Both caps are honoured *exactly* via ``tree.legal_append_targets``:
+        ``append_new_node_mutation`` is offered iff at least one attachment point keeps the
+        result within both caps. A depth cap does not forbid append outright -- append can
+        still grow a tree *wider* by attaching to a shallow node (which is how compact
+        wide trees form at e.g. ``max_depth=3``); it is excluded only when *every* point
+        would overflow. The two shrinking mutations are always depth/size-safe.
 
     Returns:
         A list of mutation functions that are valid for the given tree
     """
     logger.debug(f"Determining allowed mutations for tree with {tree.nodes_count} nodes")
     allowed_mutations: list[Callable] = []
-    if max_nodes is None or tree.nodes_count < max_nodes:
+    if tree.legal_append_targets(max_depth=max_depth, max_nodes=max_nodes):
         allowed_mutations.append(append_new_node_mutation)
 
     if tree.nodes_count >= 3:

--- a/okapi/mutation.py
+++ b/okapi/mutation.py
@@ -160,7 +160,7 @@ def new_tree_from_branch_mutation(tree: Tree, **kwargs):
     return new_tree
 
 
-def get_allowed_mutations(tree):
+def get_allowed_mutations(tree, max_nodes: int | None = None):
     """
     Determines which mutation operations are valid for a given tree.
 
@@ -169,14 +169,21 @@ def get_allowed_mutations(tree):
 
     Args:
         tree: The tree to analyze
+        max_nodes: Optional hard cap on node count. When set and the tree is already at
+            (or above) the cap, ``append_new_node_mutation`` is excluded so the search does
+            not waste effort growing trees that would only be rejected. Note the depth cap
+            is intentionally *not* applied here: append can also grow a tree *wider* without
+            increasing depth (a sibling at a shallow operator), which is exactly how compact
+            wide-shallow trees form at ``max_depth=3``. Depth is therefore enforced after the
+            mutation (see ``Okapi._within_caps``), rejecting only appends that truly deepen.
 
     Returns:
         A list of mutation functions that are valid for the given tree
     """
     logger.debug(f"Determining allowed mutations for tree with {tree.nodes_count} nodes")
-    allowed_mutations: list[Callable] = [
-        append_new_node_mutation,
-    ]
+    allowed_mutations: list[Callable] = []
+    if max_nodes is None or tree.nodes_count < max_nodes:
+        allowed_mutations.append(append_new_node_mutation)
 
     if tree.nodes_count >= 3:
         logger.trace("Tree is large enough for lose_branch_mutation")

--- a/okapi/node.py
+++ b/okapi/node.py
@@ -540,6 +540,111 @@ class WeightedMeanNode(OperatorNode):
         return True
 
 
+class WeightedLogitMeanNode(OperatorNode):
+    """Per-input weighted sum in *logit* space (the calibrated-stacking link).
+
+    ``LogitMeanNode`` applies a single global ``temperature`` to the *mean* logit;
+    ``WeightedMeanNode`` applies per-input weights but in *probability* space. This
+    node is their natural join -- per-input weights applied in logit space:
+
+    - binary single-channel ``[K, *, 1]``: ``sigmoid(Sum_i w_i * logit(x_i))``;
+    - multiclass ``[K, *, C]``: ``exp(Sum_i w_i * log(x_i))`` (weighted product rule;
+      the tree postprocessing renormalises).
+
+    The Bayes-optimal fusion of calibrated detectors with per-model noise scales
+    ``k_i`` is ``sigmoid(Sum (1/k_i) * logit p_i)`` -- i.e. this node *with* ``w_i =
+    1/k_i`` -- which probability-space averaging and a single global temperature
+    cannot express. Weights are **free and non-negative**, deliberately *not*
+    normalised to 1: their scale is the effective temperature, so ``Sum w_i ~ K``
+    recovers the independent-evidence logit *sum* and equal small weights recover
+    ``LogitMeanNode`` (it is a strict superset). The parent input occupies slot 0
+    and each child follows, mirroring ``WeightedMeanNode``; weights evolve via
+    ``mutate_params`` (additive Gaussian, floored at 0). Because there is no
+    sum-to-one constraint, the structural weight bookkeeping is simpler than
+    ``WeightedMeanNode`` -- add/remove just append/pop a free weight, no rescaling.
+    """
+
+    _EPS = 1e-6
+    _CLAMP = 30.0
+    _W_MAX = 50.0
+
+    def __init__(self, children: Optional[Sequence[ValueNode]], weights: List[float]):
+        self._weights = list(weights)
+        super().__init__(children)
+
+    def __str__(self) -> str:
+        return f"WeightedLogitMeanNode with weights: {np.round(self._weights, 2)}"
+
+    def copy(self):
+        # Mirror WeightedMeanNode: empty children + full weights; copy_subtree
+        # re-attaches the children directly, restoring length consistency.
+        return WeightedLogitMeanNode([], [w for w in self._weights])
+
+    @property
+    def code(self) -> str:
+        weights_str = ",".join(f"{w:.1f}" for w in self._weights)
+        return f"WLMN[{weights_str}]"
+
+    @property
+    def weights(self):
+        return B.tensor(self._weights)
+
+    def op(self, x):
+        xc = B.clip(x, self._EPS, 1.0 - self._EPS)
+        weight_shape = (-1, *([1] * (len(x.shape) - 1)))
+        w = B.reshape(self.weights, weight_shape)
+        w = B.to_device(w, x)  # Ensure weights are on same device as input
+        if B.shape(x)[-1] == 1:  # binary positive-probability channel -> logit space
+            z = B.log(xc) - B.log(1.0 - xc)
+            m = B.sum(w * z, axis=0)
+            m = B.clip(m, -self._CLAMP, self._CLAMP)
+            return 1.0 / (1.0 + B.exp(-m))
+        # multiclass: weighted product rule (generalises the geometric mean); PF renormalises
+        m = B.sum(w * B.log(xc), axis=0)
+        m = B.clip(m, -self._CLAMP, self._CLAMP)
+        return B.exp(m)
+
+    def add_child(self, child_node: Node):
+        logger.debug(f"Adding child to WeightedLogitMeanNode with {len(self._weights)} weights")
+        assert isinstance(child_node, ValueNode), "Child node of WLMN must be a ValueNode"
+        # Free (unnormalised) weight: a new input enters near the logit-sum scale.
+        self._weights.append(float(np.exp(np.random.normal(0.0, 0.5))))
+        super().add_child(child_node)
+        self._weight_length_assertion()
+
+    def remove_child(self, child_node: Node):
+        logger.debug(f"Removing child from WeightedLogitMeanNode with {len(self._weights)} weights")
+        assert isinstance(child_node, ValueNode), "Child node of WLMN must be a ValueNode"
+        child_ix = self.children.index(child_node)
+        self._weights.pop(child_ix + 1)  # +1: the parent input occupies slot 0
+        super().remove_child(child_node)
+        self._weight_length_assertion()
+        return child_node
+
+    def replace_child(self, child, replacement_node):
+        super().replace_child(child, replacement_node)
+        self._weight_length_assertion()
+
+    def _weight_length_assertion(self):
+        expected_length = len(self.children) + 1
+        actual_length = len(self._weights)
+        if actual_length != expected_length:
+            logger.error(f"WLMN weight length ({actual_length}) does not match expected {expected_length}")
+            assert actual_length == expected_length, "Length of weight array is different than number of adjacent nodes"
+
+    def mutate_params(self, mutation_strength: float = 0.1) -> bool:
+        noise = np.random.normal(0, mutation_strength * 3.0, len(self._weights))
+        new_weights = np.clip(np.array(self._weights) + noise, 0.0, self._W_MAX)
+        self._weights = new_weights.tolist()
+        return True
+
+    @staticmethod
+    def create_node(children: Sequence[ValueNode]):
+        n = len(children) + 1  # parent slot + one weight per child
+        weights = np.exp(np.random.normal(0.0, 0.5, size=n)).tolist()  # lognormal ~1, strictly positive
+        return WeightedLogitMeanNode(children, weights)
+
+
 class MaxNode(OperatorNode):
     """
     Represents a Max Node in a computational tree.

--- a/okapi/node.py
+++ b/okapi/node.py
@@ -644,7 +644,7 @@ class ThresholdNode(OperatorNode):
     """
 
     def __init__(self, children: Optional[Sequence[ValueNode]], threshold: float, close=True):
-        assert threshold >= 0 or threshold <= 1, f"Threshold must be between 0 and 1 (inclusive) but is equal {threshold}"
+        assert 0 <= threshold <= 1, f"Threshold must be between 0 and 1 (inclusive) but is equal {threshold}"
         super().__init__(children)
         self.close = close
         self.strclose = "Close" if self.close else "Far"

--- a/okapi/node.py
+++ b/okapi/node.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional, Sequence, TypeVar, Union, cast
 
 import numpy as np
@@ -358,6 +359,27 @@ class LogitMeanNode(OperatorNode):
         m = B.clip(m, -self._CLAMP, self._CLAMP)
         return B.exp(m)
 
+    def calculate(self):
+        running_sum = None
+        count = 0
+        binary = None
+        for tensor in self._stream_inputs():
+            if binary is None:
+                binary = B.shape(tensor)[-1] == 1
+            xc = B.clip(tensor, self._EPS, 1.0 - self._EPS)
+            transformed = B.log(xc) - B.log(1.0 - xc) if binary else B.log(xc)
+            if running_sum is None:
+                running_sum = transformed
+            else:
+                running_sum += transformed
+            count += 1
+        m = self.temperature * (running_sum / count)
+        if binary:
+            m = m + self.shift
+        m = B.clip(m, -self._CLAMP, self._CLAMP)
+        result = 1.0 / (1.0 + B.exp(-m)) if binary else B.exp(m)
+        return PF(result)
+
     def mutate_params(self, mutation_strength: float = 0.1) -> bool:
         self.temperature = float(np.clip(self.temperature + np.random.normal(0, mutation_strength * 5.0), 0.05, 50.0))
         self.shift = float(self.shift + np.random.normal(0, mutation_strength * 2.0))
@@ -604,6 +626,24 @@ class WeightedLogitMeanNode(OperatorNode):
         m = B.clip(m, -self._CLAMP, self._CLAMP)
         return B.exp(m)
 
+    def calculate(self):
+        self._weight_length_assertion()
+        running_sum = None
+        binary = None
+        for i, tensor in enumerate(self._stream_inputs()):
+            if binary is None:
+                binary = B.shape(tensor)[-1] == 1
+            xc = B.clip(tensor, self._EPS, 1.0 - self._EPS)
+            transformed = B.log(xc) - B.log(1.0 - xc) if binary else B.log(xc)
+            weighted = transformed * self._weights[i]
+            if running_sum is None:
+                running_sum = weighted
+            else:
+                running_sum += weighted
+        m = B.clip(running_sum, -self._CLAMP, self._CLAMP)
+        result = 1.0 / (1.0 + B.exp(-m)) if binary else B.exp(m)
+        return PF(result)
+
     def add_child(self, child_node: Node):
         logger.debug(f"Adding child to WeightedLogitMeanNode with {len(self._weights)} weights")
         assert isinstance(child_node, ValueNode), "Child node of WLMN must be a ValueNode"
@@ -768,6 +808,9 @@ class ThresholdNode(OperatorNode):
 
     def op(self, x):
         orig_shape = B.shape(x)
+        if x.__class__.__module__.startswith("torch"):
+            return self._op_torch_chunked(x, orig_shape)
+
         adjusted = (x - self.threshold) ** 2
         adjusted = B.reshape(adjusted, (x.shape[0], -1))
 
@@ -783,6 +826,28 @@ class ThresholdNode(OperatorNode):
         x = B.reshape(x_selected, orig_shape[1:])
 
         return x
+
+    def _op_torch_chunked(self, x, orig_shape):
+        import torch
+
+        x_reshaped = x.reshape(x.shape[0], -1)
+        n_cols = x_reshaped.shape[1]
+        chunk_size = int(os.environ.get("OKAPI_THRESHOLD_CHUNK_SIZE", "262144"))
+        selected_chunks = []
+
+        for start in range(0, n_cols, chunk_size):
+            end = min(start + chunk_size, n_cols)
+            x_chunk = x_reshaped[:, start:end]
+            adjusted = (x_chunk - self.threshold).square()
+            if self.close:
+                ixes = torch.argmin(adjusted, dim=0)
+            else:
+                ixes = torch.argmax(adjusted, dim=0)
+            col_indices = torch.arange(end - start, device=x.device)
+            selected_chunks.append(x_chunk[ixes, col_indices])
+
+        x_selected = torch.cat(selected_chunks, dim=0)
+        return x_selected.reshape(orig_shape[1:])
 
     def adjust_params(self):
         return

--- a/okapi/node.py
+++ b/okapi/node.py
@@ -309,6 +309,67 @@ class MeanNode(OperatorNode):
         return MeanNode(children)
 
 
+class LogitMeanNode(OperatorNode):
+    """Mean in logit space with a learnable temperature and shift.
+
+    The Bayes-optimal fusion of calibrated, conditionally-independent detectors is
+    additive in *logit* space, not in probability space (where ``MeanNode``
+    operates and loses information). This node maps inputs to logits, averages
+    them, applies a learnable affine recalibration ``temperature * mean_logit +
+    shift`` and maps back:
+
+    - binary single-channel ``[K, *, 1]``: ``sigmoid(temperature * mean(logit(x)) + shift)``;
+    - multiclass ``[K, *, C]``: ``exp(temperature * mean(log x))`` (a temperature-scaled
+      geometric mean / product rule), left for the tree postprocessing to renormalise.
+
+    ``temperature`` interpolates between a single-model logit (small t), a logit
+    *mean* (t=1) and a logit *sum* (t≈K, the independent-evidence optimum);
+    ``shift`` is the recalibration / decision-threshold degree of freedom that
+    probability-space operators lack. Both are evolved via ``mutate_params``.
+    """
+
+    _EPS = 1e-6
+    _CLAMP = 30.0
+
+    def __init__(self, children: Optional[Sequence[ValueNode]], temperature: float = 1.0, shift: float = 0.0):
+        super().__init__(children)
+        self.temperature = temperature
+        self.shift = shift
+
+    def __str__(self) -> str:
+        return f"LogitMeanNode(t={self.temperature:.2f}, s={self.shift:.2f})"
+
+    def copy(self):
+        return LogitMeanNode(None, self.temperature, self.shift)
+
+    @property
+    def code(self) -> str:
+        return f"LMN[{self.temperature:.1f},{self.shift:.1f}]"
+
+    def op(self, x):
+        xc = B.clip(x, self._EPS, 1.0 - self._EPS)
+        if B.shape(x)[-1] == 1:  # binary positive-probability channel -> logit space
+            z = B.log(xc) - B.log(1.0 - xc)
+            m = self.temperature * B.mean(z, axis=0) + self.shift
+            m = B.clip(m, -self._CLAMP, self._CLAMP)
+            return 1.0 / (1.0 + B.exp(-m))
+        # multiclass: temperature-scaled geometric mean (product rule); PF renormalises
+        m = self.temperature * B.mean(B.log(xc), axis=0)
+        m = B.clip(m, -self._CLAMP, self._CLAMP)
+        return B.exp(m)
+
+    def mutate_params(self, mutation_strength: float = 0.1) -> bool:
+        self.temperature = float(np.clip(self.temperature + np.random.normal(0, mutation_strength * 5.0), 0.05, 50.0))
+        self.shift = float(self.shift + np.random.normal(0, mutation_strength * 2.0))
+        return True
+
+    @staticmethod
+    def create_node(children):
+        t = float(np.exp(np.random.normal(0.0, 0.5)))  # lognormal around 1, strictly positive
+        s = float(np.random.normal(0.0, 0.3))
+        return LogitMeanNode(children, t, s)
+
+
 class WeightedMeanNode(OperatorNode):
     """
     Represents a Weighted Mean Node in a computational tree.

--- a/okapi/okapi.py
+++ b/okapi/okapi.py
@@ -66,6 +66,8 @@ class Okapi:
         seed: int = 0,
         postprocessing_function=None,
         mutation_strength: float = 0.1,
+        max_depth: int | None = None,
+        max_nodes: int | None = None,
     ):
         """
         Initialize the Okapi evolutionary algorithm.
@@ -87,6 +89,12 @@ class Okapi:
             Most of the operations may break some data characteristics, for example vector summing to one. This can be used to fix that.
             mutation_strength: Controls magnitude of parameter mutations (default 0.1).
             Higher values cause larger parameter changes during evolution.
+            max_depth: Optional hard cap on tree depth (levels; root = 1, a value->op->value
+            fusion = 3). ``None`` (default) imposes no limit and reproduces the historical
+            behaviour exactly. When set, variation never produces an individual deeper than this.
+            max_nodes: Optional hard cap on total node count. ``None`` (default) imposes no limit.
+            Both caps are enforced at generation time (mutation + crossover), not merely at
+            selection, so they also bound evaluation cost - see ``_within_caps``.
         """
         if backend is not None:
             Backend.set_backend(backend)
@@ -101,6 +109,8 @@ class Okapi:
         self.minimize_node_count = minimize_node_count
         self.mutation_strength = mutation_strength
         self.seed = seed
+        self.max_depth = max_depth
+        self.max_nodes = max_nodes
 
         self.objective_functions = objective_functions
         self.objectives = objectives
@@ -219,13 +229,44 @@ class Okapi:
 
         self.additional_population = []
 
+    def _within_caps(self, tree: Tree) -> bool:
+        """Return whether ``tree`` respects the configured ``max_depth`` / ``max_nodes`` caps.
+
+        With both caps left at their ``None`` default this is always ``True``, so the
+        historical (uncapped) behaviour is reproduced exactly. When a cap is set, this is the
+        single source of truth that *guarantees* no over-budget individual ever enters the
+        population - the mutation/crossover gates above it are only optimisations.
+        """
+        if self.max_nodes is not None and tree.nodes_count > self.max_nodes:
+            return False
+        if self.max_depth is not None and tree.depth > self.max_depth:
+            return False
+        return True
+
     def _perform_crossovers(self, fitnesses: npt.NDArray[np.float64]):
+        # How many times to re-attempt a crossover whose offspring both violate the bloat
+        # caps before falling back to parent copies. Keeps the while-loop terminating even
+        # under a punishing cap (parents are themselves within caps, so the fallback is safe).
+        cap_retries = 8
         crossover_count = 0
-        while len(self.additional_population) < (self.population_multiplier * self.population_size):
+        target = self.population_multiplier * self.population_size
+        while len(self.additional_population) < target:
             idx1, idx2 = tournament_selection_indexes(fitnesses, self.tournament_size, self.optimal_point)
             parent_1, parent_2 = self.population[idx1], self.population[idx2]
-            new_tree_1, new_tree_2 = crossover(parent_1, parent_2)
-            self.additional_population += [new_tree_1, new_tree_2]
+
+            accepted: List[Tree] = []
+            for _ in range(cap_retries):
+                new_tree_1, new_tree_2 = crossover(parent_1, parent_2)
+                accepted = [child for child in (new_tree_1, new_tree_2) if self._within_caps(child)]
+                if accepted:
+                    break
+            if not accepted:
+                # Caps too tight for these parents to recombine within budget: fall back to
+                # within-caps parent copies so the loop always makes progress.
+                logger.trace("Crossover could not satisfy bloat caps; falling back to parent copies")
+                accepted = [parent_1.copy(), parent_2.copy()]
+
+            self.additional_population += accepted
             crossover_count += 1
         return crossover_count
 
@@ -238,16 +279,24 @@ class Okapi:
 
             # Structural mutation
             if np.random.rand() < tree.mutation_chance:
-                allowed_mutations = np.array(get_allowed_mutations(tree))
-                chosen_mutation = np.random.choice(allowed_mutations)
-                logger.trace(f"Applying structural mutation: {chosen_mutation.__name__}")
-                current_tree = chosen_mutation(
-                    tree,
-                    models=self.models,
-                    ids=self.ids,
-                    allowed_ops=self.allowed_ops,
-                )
-                mutation_count += 1
+                allowed_mutations = get_allowed_mutations(tree, max_nodes=self.max_nodes)
+                if allowed_mutations:
+                    chosen_mutation = np.random.choice(np.array(allowed_mutations))
+                    logger.trace(f"Applying structural mutation: {chosen_mutation.__name__}")
+                    mutated = chosen_mutation(
+                        tree,
+                        models=self.models,
+                        ids=self.ids,
+                        allowed_ops=self.allowed_ops,
+                    )
+                    # Enforce the depth cap (and re-check nodes) after the fact: this rejects
+                    # only the appends that actually deepen the tree past the cap, while still
+                    # allowing width growth at the cap. Reverting keeps the unmutated parent.
+                    if self._within_caps(mutated):
+                        current_tree = mutated
+                        mutation_count += 1
+                    else:
+                        logger.trace("Structural mutation exceeded bloat caps; reverting")
 
             # Parameter mutation (applied to structurally mutated tree if any, else original)
             if np.random.rand() < tree.mutation_chance:

--- a/okapi/okapi.py
+++ b/okapi/okapi.py
@@ -232,10 +232,10 @@ class Okapi:
     def _within_caps(self, tree: Tree) -> bool:
         """Return whether ``tree`` respects the configured ``max_depth`` / ``max_nodes`` caps.
 
-        With both caps left at their ``None`` default this is always ``True``, so the
-        historical (uncapped) behaviour is reproduced exactly. When a cap is set, this is the
-        single source of truth that *guarantees* no over-budget individual ever enters the
-        population - the mutation/crossover gates above it are only optimisations.
+        With both caps at their ``None`` default this is always ``True`` (uncapped). When a
+        cap is set, variation now selects only cap-legal moves up front (deterministic
+        legal-target append + legal-pair crossover), so this is used as a cheap *invariant
+        assertion* after each operator rather than a generate-and-reject gate.
         """
         if self.max_nodes is not None and tree.nodes_count > self.max_nodes:
             return False
@@ -244,29 +244,17 @@ class Okapi:
         return True
 
     def _perform_crossovers(self, fitnesses: npt.NDArray[np.float64]):
-        # How many times to re-attempt a crossover whose offspring both violate the bloat
-        # caps before falling back to parent copies. Keeps the while-loop terminating even
-        # under a punishing cap (parents are themselves within caps, so the fallback is safe).
-        cap_retries = 8
         crossover_count = 0
         target = self.population_multiplier * self.population_size
         while len(self.additional_population) < target:
             idx1, idx2 = tournament_selection_indexes(fitnesses, self.tournament_size, self.optimal_point)
             parent_1, parent_2 = self.population[idx1], self.population[idx2]
-
-            accepted: List[Tree] = []
-            for _ in range(cap_retries):
-                new_tree_1, new_tree_2 = crossover(parent_1, parent_2)
-                accepted = [child for child in (new_tree_1, new_tree_2) if self._within_caps(child)]
-                if accepted:
-                    break
-            if not accepted:
-                # Caps too tight for these parents to recombine within budget: fall back to
-                # within-caps parent copies so the loop always makes progress.
-                logger.trace("Crossover could not satisfy bloat caps; falling back to parent copies")
-                accepted = [parent_1.copy(), parent_2.copy()]
-
-            self.additional_population += accepted
+            # Caps are honoured by construction: crossover draws only from points whose
+            # offspring stay within budget (value root x root is always legal, so a usable
+            # pair always exists). No retry/fallback needed; assert the invariant.
+            new_tree_1, new_tree_2 = crossover(parent_1, parent_2, max_depth=self.max_depth, max_nodes=self.max_nodes)
+            assert self._within_caps(new_tree_1) and self._within_caps(new_tree_2)
+            self.additional_population += [new_tree_1, new_tree_2]
             crossover_count += 1
         return crossover_count
 
@@ -279,7 +267,7 @@ class Okapi:
 
             # Structural mutation
             if np.random.rand() < tree.mutation_chance:
-                allowed_mutations = get_allowed_mutations(tree, max_nodes=self.max_nodes)
+                allowed_mutations = get_allowed_mutations(tree, max_depth=self.max_depth, max_nodes=self.max_nodes)
                 if allowed_mutations:
                     chosen_mutation = np.random.choice(np.array(allowed_mutations))
                     logger.trace(f"Applying structural mutation: {chosen_mutation.__name__}")
@@ -288,15 +276,15 @@ class Okapi:
                         models=self.models,
                         ids=self.ids,
                         allowed_ops=self.allowed_ops,
+                        max_depth=self.max_depth,
+                        max_nodes=self.max_nodes,
                     )
-                    # Enforce the depth cap (and re-check nodes) after the fact: this rejects
-                    # only the appends that actually deepen the tree past the cap, while still
-                    # allowing width growth at the cap. Reverting keeps the unmutated parent.
-                    if self._within_caps(mutated):
-                        current_tree = mutated
-                        mutation_count += 1
-                    else:
-                        logger.trace("Structural mutation exceeded bloat caps; reverting")
+                    # append draws only cap-legal targets; the shrinking mutations cannot
+                    # exceed a cap a within-caps parent already met. So the result is always
+                    # within caps -> assert the invariant instead of reverting.
+                    assert self._within_caps(mutated)
+                    current_tree = mutated
+                    mutation_count += 1
 
             # Parameter mutation (applied to structurally mutated tree if any, else original)
             if np.random.rand() < tree.mutation_chance:

--- a/okapi/operators.py
+++ b/okapi/operators.py
@@ -12,6 +12,7 @@ from okapi.node import (
     MaxNode,
     MeanNode,
     MinNode,
+    WeightedLogitMeanNode,
     WeightedMeanNode,
 )
 
@@ -23,3 +24,4 @@ WEIGHTED_MEAN = WeightedMeanNode
 FAR_THRESHOLD = FarThresholdNode
 CLOSE_THRESHOLD = CloseThresholdNode
 LOGIT_MEAN = LogitMeanNode
+WEIGHTED_LOGIT_MEAN = WeightedLogitMeanNode

--- a/okapi/operators.py
+++ b/okapi/operators.py
@@ -5,7 +5,15 @@ This module exposes the various operator node types from okapi.node
 with simpler names for easier importing and usage.
 """
 
-from okapi.node import CloseThresholdNode, FarThresholdNode, MaxNode, MeanNode, MinNode, WeightedMeanNode
+from okapi.node import (
+    CloseThresholdNode,
+    FarThresholdNode,
+    LogitMeanNode,
+    MaxNode,
+    MeanNode,
+    MinNode,
+    WeightedMeanNode,
+)
 
 # Operator node types available for use in trees
 MIN = MinNode
@@ -14,3 +22,4 @@ MEAN = MeanNode
 WEIGHTED_MEAN = WeightedMeanNode
 FAR_THRESHOLD = FarThresholdNode
 CLOSE_THRESHOLD = CloseThresholdNode
+LOGIT_MEAN = LogitMeanNode

--- a/okapi/pareto.py
+++ b/okapi/pareto.py
@@ -127,7 +127,7 @@ def plot_pareto_frontier(array: np.ndarray, objectives: Sequence[Callable[[float
         # For two objectives, we typically want to sort by one coordinate
         # The sort direction depends on whether we're maximizing or minimizing
         sort_col = 0
-        sort_ascending = isinstance(objectives[0], type(minimize))
+        sort_ascending = objectives[0] is minimize
 
         # Sort the Pareto points
         sorted_indices = np.argsort(pareto_points[:, sort_col])

--- a/okapi/population.py
+++ b/okapi/population.py
@@ -100,8 +100,10 @@ def choose_pareto(trees: List[Tree], fitnesses: np.ndarray, n: int, objectives: 
         logger.debug(f"Too many Pareto-optimal trees ({len(pareto_indices)}), selecting top {n} by proximity")
         if minimize_node_count:
             objectives = objectives[:-1]
-        _, sorted_indices = sort_by_optimal_point_proximity(fitnesses, objectives)
-        selected_indices = sorted_indices[:n]
+        # Rank only the Pareto-optimal trees by proximity, never the dominated ones.
+        pareto_fitnesses = fitnesses[pareto_indices]
+        _, sorted_indices = sort_by_optimal_point_proximity(pareto_fitnesses, objectives)
+        selected_indices = pareto_indices[sorted_indices[:n]]
     else:
         selected_indices = pareto_indices
         logger.debug(f"Using all {len(selected_indices)} Pareto-optimal trees")

--- a/okapi/shrinkage.py
+++ b/okapi/shrinkage.py
@@ -1,0 +1,34 @@
+"""Prediction-level shrinkage helpers for OKAPI ensembles.
+
+The functions in this module are deliberately independent from the evolutionary
+loop. They can be used for post-hoc saved-front analysis now and for a later
+fitness-wrapped in-training condition without adding a new tree node type.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def shrink_prediction(tree_prediction: T, provider_prediction: T, alpha: float) -> T:
+    """Blend a candidate prediction with a robust provider prediction.
+
+    ``alpha=0`` returns the original candidate prediction and ``alpha=1`` returns
+    the provider prediction. The function works with NumPy arrays, PyTorch
+    tensors, and other array-like objects supporting scalar arithmetic.
+    """
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(f"alpha must be in [0, 1], got {alpha}")
+    return (1.0 - alpha) * tree_prediction + alpha * provider_prediction
+
+
+def average_predictions(predictions: Sequence[T]) -> T:
+    """Return the arithmetic mean of prediction tensors/arrays."""
+    if not predictions:
+        raise ValueError("cannot average an empty prediction sequence")
+    total = predictions[0]
+    for prediction in predictions[1:]:
+        total = total + prediction
+    return total / len(predictions)

--- a/okapi/tree.py
+++ b/okapi/tree.py
@@ -349,7 +349,7 @@ class Tree:
 
         for nodes_type in nodes_types:
             assert nodes_type is not None, "Nodes type cannot be None"
-            order = np.arange(len(self.nodes[nodes_type]))
+            order = np.random.permutation(len(self.nodes[nodes_type]))
             for i in order:
                 node = self.nodes[nodes_type][i]
                 if (allow_leaves or node.children != []) and (allow_root or node != self.root):
@@ -439,7 +439,8 @@ class Tree:
             [current_tensors is not None, preds_directory is not None]
         ), "Either preds directory or current tensors needs to be set, none was set"
 
-        current_tensors = {}
+        if current_tensors is None:
+            current_tensors = {}
         copy_tree = self.copy()
         copy_tree._clean_values_and_evals()
         current_tensors = copy_tree._load_tensors_to_tree(preds_directory, current_tensors)

--- a/okapi/tree.py
+++ b/okapi/tree.py
@@ -122,6 +122,41 @@ class Tree:
 
         return _node_depth(self.root)
 
+    def _depth_map(self) -> dict:
+        """Map every node to its depth from the root (root = 1), in one traversal."""
+        depth = {self.root: 1}
+        stack = [self.root]
+        while stack:
+            node = stack.pop()
+            d = depth[node]
+            for child in node.children:
+                depth[child] = d + 1
+                stack.append(child)
+        return depth
+
+    def legal_append_targets(self, max_depth: int | None = None, max_nodes: int | None = None) -> list:
+        """Nodes to which ``append_new_node_mutation`` can attach within the bloat caps.
+
+        Appending to a ValueNode inserts an operator + value child (depth +2, nodes +2);
+        appending to an OperatorNode inserts a value child (depth +1, nodes +1). A node is
+        a legal target iff the resulting tree still respects both caps. With both caps
+        ``None`` every node qualifies (the uncapped behaviour). This is the basis of the
+        deterministic, retry-free cap enforcement: the search only ever *selects* a legal
+        attachment point instead of generating an illegal one and rejecting it. A depth cap
+        therefore never forbids appending outright -- it just restricts growth to shallow
+        nodes, which is exactly how compact *wide* trees form at e.g. ``max_depth=3``.
+        """
+        n = self.nodes_count
+        depth_of = self._depth_map()
+        targets: list = []
+        for node in self.nodes["value_nodes"]:
+            if (max_nodes is None or n + 2 <= max_nodes) and (max_depth is None or depth_of[node] + 2 <= max_depth):
+                targets.append(node)
+        for node in self.nodes["op_nodes"]:
+            if (max_nodes is None or n + 1 <= max_nodes) and (max_depth is None or depth_of[node] + 1 <= max_depth):
+                targets.append(node)
+        return targets
+
     def _clean_evals(self):
         """
         Reset the cached evaluation results for all value nodes in the tree.

--- a/okapi/tree.py
+++ b/okapi/tree.py
@@ -103,6 +103,25 @@ class Tree:
         """
         return len(self.nodes["value_nodes"]) + len(self.nodes["op_nodes"])
 
+    @property
+    def depth(self) -> int:
+        """
+        Maximum depth of the tree, measured in node levels.
+
+        The root ValueNode is level 1; a ``value -> operator -> value`` fusion has
+        depth 3. This matches the convention used by the saved-tree depth scanners
+        (``experiments/scan_tree_depths.py`` / ``experiments/depth_probe.py``) so that
+        in-evolution caps and post-hoc audits speak the same units.
+
+        Returns:
+            The number of levels from the root to the deepest leaf.
+        """
+
+        def _node_depth(node) -> int:
+            return 1 if not node.children else 1 + max(_node_depth(child) for child in node.children)
+
+        return _node_depth(self.root)
+
     def _clean_evals(self):
         """
         Reset the cached evaluation results for all value nodes in the tree.

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -183,3 +183,24 @@ def test_clone_is_independent_copy():
         # Either way, cloned should be independent
         cloned_np = B.to_numpy(cloned)
         assert cloned_np[0, 0] != 999.0 or B.__name__ == "NumpyBackend"
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        [0.0, 1.0, 2.0],
+        [[-1.0, 0.0], [1.0, 2.0]],
+    ],
+)
+def test_exp(array):
+    for B in BACKENDS:
+        tensor = B.tensor(array)
+        result = B.to_numpy(B.exp(tensor))
+        np.testing.assert_allclose(result, np.exp(np.asarray(array, dtype=float)), rtol=1e-5)
+
+
+def test_log_exp_roundtrip():
+    for B in BACKENDS:
+        tensor = B.tensor([0.1, 0.5, 0.9, 1.0, 3.0])
+        result = B.to_numpy(B.exp(B.log(tensor)))
+        np.testing.assert_allclose(result, [0.1, 0.5, 0.9, 1.0, 3.0], rtol=1e-5)

--- a/test/test_bloat_control.py
+++ b/test/test_bloat_control.py
@@ -1,0 +1,190 @@
+"""Bloat / depth control (Track C1).
+
+Covers the depth/size primitives and the hard ``max_depth`` / ``max_nodes`` caps that
+are enforced at generation time. The caps default to ``None`` (no limit), which must
+reproduce the historical uncapped behaviour exactly; when set, no individual deeper /
+larger than the cap may ever enter the population, and the search must still terminate
+even under a punishing cap (bounded-retry crossover + parent-copy fallback).
+"""
+
+import time
+
+import numpy as np
+import pytest
+
+from okapi.mutation import append_new_node_mutation, get_allowed_mutations
+from okapi.node import MeanNode, ValueNode
+from okapi.okapi import Okapi
+from okapi.pareto import maximize
+from okapi.tree import Tree
+
+
+def _identity(x):
+    return x
+
+
+def _vnode(model_id="m"):
+    return ValueNode(None, np.array([[0.6, 0.4], [0.3, 0.7]]), model_id)
+
+
+def _fusion_tree(model_ids=("a", "b", "c")):
+    """A single-operator fusion: root value -> op -> children values (depth 3)."""
+    root = _vnode(model_ids[0])
+    op = MeanNode(None)
+    for mid in model_ids[1:]:
+        op.add_child(_vnode(mid))
+    root.add_child(op)
+    return Tree.create_tree_from_root(root)
+
+
+def _node_depth(node):
+    return 1 if not node.children else 1 + max(_node_depth(c) for c in node.children)
+
+
+def _deep_chain_tree(depth_levels=5):
+    """A value/operator alternating chain with the requested (odd) depth in levels."""
+    assert depth_levels % 2 == 1 and depth_levels >= 1
+    node = _vnode("leaf")  # depth 1
+    while _node_depth(node) < depth_levels:
+        op = MeanNode(None)
+        op.add_child(node)
+        parent_value = _vnode("v")
+        parent_value.add_child(op)
+        node = parent_value  # adds two levels (value -> op -> ...)
+    return Tree.create_tree_from_root(node)
+
+
+# --------------------------------------------------------------------------- #
+# Tree.depth (pure)
+# --------------------------------------------------------------------------- #
+
+
+def test_depth_single_node_is_one():
+    assert Tree.create_tree_from_root(_vnode()).depth == 1
+
+
+def test_depth_single_fusion_is_three():
+    tree = _fusion_tree()
+    assert tree.depth == 3
+    assert tree.nodes_count == 4
+
+
+def test_depth_matches_scanner_convention_on_deep_chain():
+    tree = _deep_chain_tree(5)
+    assert tree.depth == 5
+
+
+# --------------------------------------------------------------------------- #
+# get_allowed_mutations gate (append dropped only at the node cap)
+# --------------------------------------------------------------------------- #
+
+
+def test_append_allowed_when_under_node_cap():
+    tree = _fusion_tree()  # 4 nodes
+    assert append_new_node_mutation in get_allowed_mutations(tree, max_nodes=None)
+    assert append_new_node_mutation in get_allowed_mutations(tree, max_nodes=5)
+
+
+def test_append_dropped_at_or_above_node_cap():
+    tree = _fusion_tree()  # 4 nodes
+    assert append_new_node_mutation not in get_allowed_mutations(tree, max_nodes=4)
+    assert append_new_node_mutation not in get_allowed_mutations(tree, max_nodes=3)
+
+
+def test_depth_does_not_gate_append_so_width_growth_survives():
+    # A depth-3 tree must still be allowed to append (grow wider) — depth is enforced
+    # post-hoc, not by removing append, so wide-shallow trees can form at max_depth=3.
+    tree = _fusion_tree()
+    assert append_new_node_mutation in get_allowed_mutations(tree, max_nodes=None)
+
+
+# --------------------------------------------------------------------------- #
+# Engine integration
+# --------------------------------------------------------------------------- #
+
+
+def _acc(prediction, gt):
+    p = np.asarray(prediction)
+    y = np.asarray(gt).ravel().astype(int)
+    yhat = (p[:, 0] > 0.5).astype(int) if p.shape[1] == 1 else p.argmax(axis=1)
+    return float((yhat == y).mean())
+
+
+def _make_engine(tmp_path, *, n_models=10, n=200, max_depth=None, max_nodes=None,
+                 minimize_node_count=True, seed=0, pop=10):
+    rng = np.random.default_rng(seed)
+    fit_dir = tmp_path / "fit"
+    fit_dir.mkdir(parents=True)
+    for k in range(n_models):
+        np.save(fit_dir / f"m{k}.npy", rng.random((n, 1)).astype(np.float64))
+    gt_path = tmp_path / "gt.npy"
+    np.save(gt_path, (rng.random(n) > 0.5).astype(np.int64))
+    return Okapi(
+        preds_source=fit_dir,
+        gt_path=gt_path,
+        population_size=pop,
+        population_multiplier=3,
+        tournament_size=4,
+        minimize_node_count=minimize_node_count,
+        objective_functions=(_acc,),
+        objectives=(maximize,),
+        backend="numpy",
+        seed=seed,
+        postprocessing_function=_identity,
+        max_depth=max_depth,
+        max_nodes=max_nodes,
+    )
+
+
+def test_engine_caps_default_to_none(tmp_path):
+    ok = _make_engine(tmp_path)
+    assert ok.max_depth is None and ok.max_nodes is None
+
+
+def test_within_caps_rejects_oversized_trees(tmp_path):
+    # Deterministic proof the cap mechanism is sound, independent of evolution dynamics.
+    ok = _make_engine(tmp_path, max_depth=3, max_nodes=6)
+    shallow = _fusion_tree()                 # depth 3, 4 nodes
+    deep = _deep_chain_tree(5)               # depth 5
+    assert ok._within_caps(shallow)
+    assert not ok._within_caps(deep)         # exceeds max_depth
+
+    ok_nodes = _make_engine(tmp_path / "b", max_nodes=3)
+    assert not ok_nodes._within_caps(shallow)  # 4 nodes > 3
+
+
+def test_max_depth_cap_never_exceeded(tmp_path):
+    ok = _make_engine(tmp_path, max_depth=3, minimize_node_count=False, seed=1)
+    ok.train(40)
+    assert all(t.depth <= 3 for t in ok.population)
+    assert all(t.depth <= 3 for t in ok.pareto_trees)
+
+
+def test_max_nodes_cap_never_exceeded(tmp_path):
+    ok = _make_engine(tmp_path, max_nodes=7, minimize_node_count=False, seed=2)
+    ok.train(40)
+    assert all(t.nodes_count <= 7 for t in ok.population)
+    assert all(t.nodes_count <= 7 for t in ok.pareto_trees)
+
+
+def test_uncapped_search_grows_beyond_depth_three(tmp_path):
+    # Control: with no cap and no parsimony pressure the search builds trees deeper
+    # than 3 levels, proving the caps above are actually binding (not vacuous).
+    ok = _make_engine(tmp_path, max_depth=None, minimize_node_count=False, seed=3)
+    ok.train(80)
+    assert max(t.depth for t in ok.population) > 3
+
+
+def test_tight_cap_terminates(tmp_path):
+    # Punishing cap: bounded-retry crossover + parent-copy fallback must keep the
+    # evolution loop terminating, with every individual within both caps.
+    start = time.time()
+    ok = _make_engine(tmp_path, max_depth=3, max_nodes=4, minimize_node_count=False, seed=5)
+    ok.train(30)
+    assert time.time() - start < 180
+    assert ok.population, "population must remain non-empty under a tight cap"
+    assert all(t.depth <= 3 and t.nodes_count <= 4 for t in ok.population)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/test_bloat_control.py
+++ b/test/test_bloat_control.py
@@ -12,6 +12,7 @@ import time
 import numpy as np
 import pytest
 
+from okapi.crossover import _legal_crossover_pair, crossover
 from okapi.mutation import append_new_node_mutation, get_allowed_mutations
 from okapi.node import MeanNode, ValueNode
 from okapi.okapi import Okapi
@@ -184,6 +185,98 @@ def test_tight_cap_terminates(tmp_path):
     assert time.time() - start < 180
     assert ok.population, "population must remain non-empty under a tight cap"
     assert all(t.depth <= 3 and t.nodes_count <= 4 for t in ok.population)
+
+
+# --------------------------------------------------------------------------- #
+# C1b: deterministic legal-target selection (no retry, no revert)
+# --------------------------------------------------------------------------- #
+
+
+def test_legal_append_targets_depth_budget():
+    tree = _fusion_tree()  # depth 3: root(V,1) -> op(2) -> [V,V](3); 4 nodes
+    depth_of = tree._depth_map()
+    root = tree.root
+    op = tree.nodes["op_nodes"][0]
+    leaves = [v for v in tree.nodes["value_nodes"] if depth_of[v] == 3]
+
+    # max_depth=3: only shallow nodes can host an append without deepening past 3.
+    t3 = tree.legal_append_targets(max_depth=3)
+    assert root in t3 and op in t3
+    assert all(leaf not in t3 for leaf in leaves)
+    # max_depth=5: the depth-3 leaves become legal (value target adds two levels -> 5).
+    t5 = tree.legal_append_targets(max_depth=5)
+    assert all(leaf in t5 for leaf in leaves)
+    # uncapped: every node is a legal target.
+    assert len(tree.legal_append_targets()) == tree.nodes_count
+
+
+def test_legal_append_targets_node_budget():
+    tree = _fusion_tree()  # 4 nodes
+    op = tree.nodes["op_nodes"][0]
+    # Room for exactly one node: only an op target (adds 1) qualifies, not a value (adds 2).
+    t5 = tree.legal_append_targets(max_nodes=5)
+    assert op in t5 and tree.root not in t5
+    # No room at all.
+    assert tree.legal_append_targets(max_nodes=4) == []
+
+
+def test_capped_append_grows_width_not_depth():
+    # The capability the deterministic selector unlocks over the bugged shallow-only
+    # search: at max_depth=3 append still fires, building WIDER depth-3 trees, never deeper.
+    np.random.seed(0)
+    models = [np.full((2, 1), 0.5) for _ in range(5)]
+    ids = [f"m{i}" for i in range(5)]
+    tree = _fusion_tree()
+    for _ in range(6):
+        tree = append_new_node_mutation(tree, models, ids, allowed_ops=(MeanNode,), max_depth=3)
+    assert tree.depth == 3          # never deepened past the cap
+    assert tree.nodes_count > 4     # but grew wider than the minimal single fusion
+
+
+def test_capped_append_no_legal_target_is_noop():
+    # A 4-node fusion at max_nodes=4 has no legal attachment point -> unchanged copy.
+    np.random.seed(0)
+    models = [np.full((2, 1), 0.5) for _ in range(3)]
+    ids = ["m0", "m1", "m2"]
+    tree = _fusion_tree()
+    out = append_new_node_mutation(tree, models, ids, allowed_ops=(MeanNode,), max_nodes=4)
+    assert out.nodes_count == tree.nodes_count
+
+
+def test_crossover_offspring_respect_caps():
+    np.random.seed(1)
+    t1 = _fusion_tree(("a", "b", "c"))  # both within caps (depth 3)
+    t2 = _fusion_tree(("d", "e", "f"))
+    for _ in range(100):
+        o1, o2 = crossover(t1, t2, max_depth=3, max_nodes=8)
+        assert o1.depth <= 3 and o2.depth <= 3
+        assert o1.nodes_count <= 8 and o2.nodes_count <= 8
+
+
+def test_legal_crossover_value_pair_always_exists():
+    # value root x root swaps whole within-caps trees -> always legal, even at the
+    # tightest binding cap, so the engine path never needs a retry or parent-copy fallback.
+    t1 = _fusion_tree(("a", "b", "c"))
+    t2 = _fusion_tree(("d", "e", "f"))
+    pair = _legal_crossover_pair(
+        t1, t2, "value_nodes",
+        max_depth=max(t1.depth, t2.depth),
+        max_nodes=max(t1.nodes_count, t2.nodes_count),
+    )
+    assert pair is not None
+
+
+def test_legal_crossover_pair_excludes_deep_into_shallow_swaps():
+    # Grafting t2's whole height-3 tree onto a depth-3 leaf of t1 would make depth 5;
+    # the filter must never offer that pair at max_depth=3 (deterministic exclusion).
+    t1 = _fusion_tree(("a", "b", "c"))
+    t2 = _fusion_tree(("d", "e", "f"))
+    depth1 = t1._depth_map()
+    deep_leaf = next(v for v in t1.nodes["value_nodes"] if depth1[v] == 3)
+    root2 = t2.root
+    for _ in range(100):
+        n1, n2 = _legal_crossover_pair(t1, t2, "value_nodes", max_depth=3, max_nodes=None)
+        assert not (n1 is deep_leaf and n2 is root2)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/test/test_core_bug_fixes.py
+++ b/test/test_core_bug_fixes.py
@@ -1,0 +1,169 @@
+"""Regression tests for core OKAPI bugs found in the 2026-06-25 code review.
+
+Each test is named after the bug it pins. They are written to FAIL on the
+pre-fix code and PASS after the fix, so they double as documentation of the
+defect. See the PR description / vault note for the full review.
+"""
+
+import numpy as np
+import pytest
+import torch
+from loguru import logger
+from matplotlib import pyplot as plt
+
+from okapi.backend.pytorch import PyTorchBackend
+from okapi.crossover import tournament_selection_indexes
+from okapi.node import MeanNode, ThresholdNode, ValueNode
+from okapi.pareto import maximize, minimize, plot_pareto_frontier
+from okapi.population import choose_pareto
+from okapi.tree import Tree
+
+
+def _const(value: float) -> np.ndarray:
+    return np.full((2, 2), float(value))
+
+
+def _mean_tree(a: float, d: float, e: float) -> Tree:
+    """root A -> MeanNode -> [D, E]; ids 'A','D','E'."""
+    root = ValueNode(None, _const(a), "A")
+    op = MeanNode(None)
+    root.add_child(op)
+    op.add_child(ValueNode(None, _const(d), "D"))
+    op.add_child(ValueNode(None, _const(e), "E"))
+    return Tree.create_tree_from_root(root)
+
+
+# --- Bug 1: get_random_node never shuffled (tree.py) ----------------------------
+
+
+def test_get_random_node_is_shuffled():
+    """Pre-fix `order = np.arange(...)` always returned the first valid node,
+    so variation operators only ever touched one position. After the fix it
+    must sample across all value nodes."""
+    root = ValueNode(None, _const(2), "A")
+    op = MeanNode(None)
+    root.add_child(op)
+    for vid in ("D", "E", "G"):
+        op.add_child(ValueNode(None, _const(3), vid))
+    tree = Tree.create_tree_from_root(root)
+
+    np.random.seed(0)
+    seen = {tree.get_random_node("value_nodes").id for _ in range(200)}
+
+    assert len(seen) > 1, "get_random_node always returns the same node — not shuffled"
+    assert seen <= {"A", "D", "E", "G"}
+
+
+# --- Bug 2: ThresholdNode assertion used `or` (always true) (node.py) ------------
+
+
+@pytest.mark.parametrize("bad", [1.5, -0.5, 2.0, -0.001, 100.0])
+def test_threshold_node_rejects_out_of_range(bad):
+    with pytest.raises(AssertionError):
+        ThresholdNode(None, bad)
+
+
+@pytest.mark.parametrize("good", [0.0, 0.25, 0.5, 1.0])
+def test_threshold_node_accepts_in_range(good):
+    node = ThresholdNode(None, good)
+    assert node.threshold == good
+
+
+# --- Bug 3: do_pred_on_another_tensors overwrote current_tensors (tree.py) -------
+
+
+def test_do_pred_on_another_tensors_uses_passed_tensors():
+    """Pre-fix the unconditional `current_tensors = {}` discarded the argument,
+    raising KeyError. The result must reflect the *passed* tensors."""
+    tree = _mean_tree(1, 2, 3)
+
+    new_tensors = {"A": _const(10), "D": _const(20), "E": _const(30)}
+    result = tree.do_pred_on_another_tensors(current_tensors=new_tensors)
+
+    reference = _mean_tree(10, 20, 30)
+    np.testing.assert_allclose(np.asarray(result), np.asarray(reference.evaluation))
+    # It must actually use the new tensors, not the tree's original values.
+    assert not np.allclose(np.asarray(result), np.asarray(tree.evaluation))
+
+
+# --- Bug 4: choose_pareto could keep dominated trees when truncating ------------
+
+
+def test_choose_pareto_excludes_dominated_when_truncating(monkeypatch):
+    """With more Pareto trees than `n`, pre-fix sorted ALL trees by proximity and
+    could keep a high-fitness *dominated* tree. Pareto set = {A,B,C}; D (0.8, 10
+    nodes) is dominated by C (0.9, 5 nodes). Truncating to 2 must give {C,B}."""
+    counts = {"A": 1, "B": 2, "C": 5, "D": 10}
+    fitness = {"A": 0.3, "B": 0.5, "C": 0.9, "D": 0.8}
+    ids = ["A", "B", "C", "D"]
+
+    trees = [Tree(ValueNode(children=None, value=np.array([0.5]), id=i)) for i in ids]
+    monkeypatch.setattr(Tree, "nodes_count", property(lambda t: counts[str(t.root.id)]))
+    fitnesses = np.array([[fitness[i]] for i in ids])
+
+    selected, _ = choose_pareto(trees, fitnesses, 2, [maximize])
+    selected_ids = {t.root.id for t in selected}
+
+    assert "D" not in selected_ids, "dominated tree D was selected over a Pareto tree"
+    assert selected_ids == {"C", "B"}
+
+
+# --- Bug 5: PyTorchBackend.to_numpy missing .cpu() (pytorch.py) -----------------
+
+
+def test_to_numpy_handles_cpu_tensor():
+    out = PyTorchBackend.to_numpy(torch.tensor([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(out, np.array([1.0, 2.0, 3.0]))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_to_numpy_handles_gpu_tensor():
+    """The actual fix target: pre-fix `.numpy()` raised on CUDA tensors."""
+    out = PyTorchBackend.to_numpy(torch.tensor([1.0, 2.0]).cuda())
+    np.testing.assert_array_equal(out, np.array([1.0, 2.0]))
+
+
+# --- Bug 6: plot_pareto_frontier sort direction always ascending (pareto.py) ----
+
+
+def test_plot_pareto_frontier_sorts_descending_for_maximize():
+    pts = np.random.RandomState(0).rand(40, 2)
+    fig, ax = plot_pareto_frontier(pts, [maximize, maximize])
+    try:
+        red = [ln for ln in ax.lines if ln.get_color() == "red"]
+        assert red, "frontier line was not drawn"
+        x = np.asarray(red[0].get_xdata())
+        assert x.size >= 2
+        assert np.all(np.diff(x) <= 1e-9), "maximize frontier should be sorted descending"
+    finally:
+        plt.close(fig)
+
+
+def test_plot_pareto_frontier_sorts_ascending_for_minimize():
+    pts = np.random.RandomState(1).rand(40, 2)
+    fig, ax = plot_pareto_frontier(pts, [minimize, minimize])
+    try:
+        red = [ln for ln in ax.lines if ln.get_color() == "red"]
+        assert red, "frontier line was not drawn"
+        x = np.asarray(red[0].get_xdata())
+        assert x.size >= 2
+        assert np.all(np.diff(x) >= -1e-9), "minimize frontier should be sorted ascending"
+    finally:
+        plt.close(fig)
+
+
+# --- Bug 7: tournament_selection_indexes warning text was backwards (crossover) -
+
+
+def test_tournament_warning_says_large():
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        # pop = 3 < 2 * tournament_size (4) -> the warning fires
+        tournament_selection_indexes(np.array([[0.1], [0.2], [0.3]]), tournament_size=2)
+    finally:
+        logger.remove(sink_id)
+
+    joined = " ".join(messages)
+    assert "large relative to the population" in joined
+    assert "small related" not in joined

--- a/test/test_logit_mean_node.py
+++ b/test/test_logit_mean_node.py
@@ -124,6 +124,23 @@ def test_in_tree_calculate_binary():
     assert out.shape == (2, 1)
 
 
+@pytest.mark.parametrize("shape", [(5, 1), (4, 3), (4, 3, 2)])
+def test_calculate_streaming_matches_op_concat(shape):
+    rng = np.random.default_rng(10)
+    a = rng.uniform(0.01, 0.99, size=shape)
+    c = rng.uniform(0.01, 0.99, size=shape)
+    d = rng.uniform(0.01, 0.99, size=shape)
+    node = LogitMeanNode(None, 1.4, -0.3)
+    ref = node.op(np.stack([a, c, d], axis=0))
+
+    A = ValueNode(None, a, "A")
+    C = ValueNode(None, c, "C")
+    D = ValueNode(None, d, "D")
+    A.add_child(LogitMeanNode([C, D], 1.4, -0.3))
+
+    np.testing.assert_allclose(A.calculate(), ref, atol=1e-9)
+
+
 # ------------------------------------ GP plumbing ----------------------------------
 
 

--- a/test/test_logit_mean_node.py
+++ b/test/test_logit_mean_node.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``LogitMeanNode`` — a logit-space fusion operator with a
+learnable temperature and shift — and its GP plumbing (create_node /
+mutate_params / copy / code), mirroring the conventions in test_node.py.
+
+The Bayes-optimal fusion of calibrated, conditionally-independent detectors is
+additive in logit space; these tests pin the operator's maths (binary sigmoid of
+the mean logit; temperature=K recovers the logit *sum*; multiclass geometric
+mean), its overflow safety, and the hooks the evolutionary search relies on.
+"""
+
+import numpy as np
+import pytest
+
+from okapi.globals import _passthrough, set_postprocessing_function
+from okapi.node import (
+    LogitMeanNode,
+    MeanNode,
+    ValueNode,
+    check_if_both_types_operators,
+)
+from okapi.operators import LOGIT_MEAN
+
+
+@pytest.fixture(autouse=True)
+def _default_passthrough_postprocessing():
+    """The global postprocessing function is shared state; ensure the default
+    passthrough so the maths assertions hold regardless of test ordering."""
+    set_postprocessing_function(_passthrough)
+    yield
+    set_postprocessing_function(_passthrough)
+
+
+def _sigmoid(z):
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def _logit(p):
+    return np.log(p) - np.log(1.0 - p)
+
+
+# ------------------------------- op() maths (binary) -------------------------------
+
+
+def test_binary_idempotent_when_inputs_equal():
+    # all K inputs equal p -> output p (temperature=1, shift=0)
+    x = np.full((3, 5, 1), 0.8)
+    out = LogitMeanNode(None, 1.0, 0.0).op(x)
+    np.testing.assert_allclose(out, 0.8, atol=1e-9)
+    assert out.shape == (5, 1)
+
+
+def test_binary_matches_reference_for_random_temperature_shift():
+    rng = np.random.default_rng(0)
+    x = rng.uniform(0.01, 0.99, size=(4, 7, 1))
+    t, s = 1.7, -0.4
+    out = LogitMeanNode(None, t, s).op(x)
+    ref = _sigmoid(t * _logit(x).mean(axis=0) + s)
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+
+
+def test_binary_temperature_equals_K_recovers_logit_sum():
+    # the independent-evidence optimum is the sum of logits; mean*K == sum
+    rng = np.random.default_rng(1)
+    K = 3
+    x = rng.uniform(0.05, 0.95, size=(K, 6, 1))
+    out = LogitMeanNode(None, float(K), 0.0).op(x)
+    ref_sum = _sigmoid(_logit(x).sum(axis=0))
+    np.testing.assert_allclose(out, ref_sum, atol=1e-9)
+
+
+def test_binary_higher_temperature_is_more_confident():
+    x = np.full((3, 1, 1), 0.8)  # mean logit > 0
+    low = LogitMeanNode(None, 1.0, 0.0).op(x).item()
+    high = LogitMeanNode(None, 5.0, 0.0).op(x).item()
+    assert high > low > 0.5
+
+
+def test_binary_shift_moves_decision_boundary():
+    # at p that gives mean logit 0, output is 0.5; a positive shift pushes it up
+    x = np.full((2, 1, 1), 0.5)
+    assert LogitMeanNode(None, 1.0, 0.0).op(x).item() == pytest.approx(0.5)
+    assert LogitMeanNode(None, 1.0, 1.0).op(x).item() > 0.5
+    assert LogitMeanNode(None, 1.0, -1.0).op(x).item() < 0.5
+
+
+@pytest.mark.parametrize("p", [0.0, 1.0])
+def test_binary_extremes_finite_and_in_unit_interval(p):
+    x = np.full((4, 3, 1), p)  # clipped internally -> no inf
+    out = LogitMeanNode(None, 5.0, 0.0).op(x)
+    assert np.isfinite(out).all()
+    assert (out > 0).all() and (out < 1).all()
+
+
+# ----------------------------- op() maths (multiclass) -----------------------------
+
+
+def test_multiclass_matches_geometric_mean_prenorm():
+    rng = np.random.default_rng(2)
+    x = rng.uniform(0.01, 0.99, size=(3, 5, 4))
+    x = x / x.sum(axis=-1, keepdims=True)
+    out = LogitMeanNode(None, 1.0, 0.0).op(x)
+    ref = np.exp(np.log(x).mean(axis=0))  # geometric mean, before renormalisation
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+    assert out.shape == (5, 4)
+    assert (out > 0).all()
+
+
+# --------------------------------- tree integration --------------------------------
+
+
+def test_in_tree_calculate_binary():
+    # A -> B(LogitMean) -> [C, D]; _concat stacks [A, C, D] -> sigmoid(mean logit)
+    a = np.array([[0.6], [0.7]])
+    c = np.array([[0.8], [0.2]])
+    d = np.array([[0.5], [0.9]])
+    A = ValueNode(None, a, "A")
+    C = ValueNode(None, c, "C")
+    D = ValueNode(None, d, "D")
+    A.add_child(LogitMeanNode([C, D], 1.0, 0.0))
+
+    out = A.calculate()
+    ref = _sigmoid(_logit(np.stack([a, c, d], axis=0)).mean(axis=0))
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+    assert out.shape == (2, 1)
+
+
+# ------------------------------------ GP plumbing ----------------------------------
+
+
+def test_create_node_positive_temperature_and_children():
+    c = ValueNode(None, np.zeros((2, 1)), "c")
+    node = LogitMeanNode.create_node([c])
+    assert isinstance(node, LogitMeanNode)
+    assert node.temperature > 0.0
+    assert node.children == [c]
+    assert c.parent is node
+
+
+def test_mutate_params_returns_true_and_moves_params():
+    np.random.seed(0)
+    node = LogitMeanNode(None, 1.0, 0.0)
+    t0, s0 = node.temperature, node.shift
+    assert node.mutate_params() is True
+    assert (node.temperature != t0) or (node.shift != s0)
+
+
+def test_mutate_params_keeps_temperature_in_bounds():
+    node = LogitMeanNode(None, 0.05, 0.0)
+    for _ in range(200):
+        node.mutate_params(0.5)
+        assert 0.05 <= node.temperature <= 50.0
+
+
+def test_copy_preserves_params_and_detaches():
+    node = LogitMeanNode(None, 2.3, -0.7)
+    cp = node.copy()
+    assert isinstance(cp, LogitMeanNode)
+    assert cp.temperature == 2.3 and cp.shift == -0.7
+    assert cp.children == [] and cp.parent is None
+
+
+def test_code_reflects_params_for_dedup():
+    assert LogitMeanNode(None, 1.0, 0.0).code == "LMN[1.0,0.0]"
+    # equal to one decimal -> identical code (deduplicated)
+    assert LogitMeanNode(None, 1.04, 0.42).code == LogitMeanNode(None, 0.96, 0.38).code
+    # materially different params -> different code
+    assert LogitMeanNode(None, 1.0, 0.0).code != LogitMeanNode(None, 2.0, 0.0).code
+
+
+def test_registered_as_operator_alias():
+    assert LOGIT_MEAN is LogitMeanNode
+
+
+def test_is_operator_for_crossover_typecheck():
+    assert check_if_both_types_operators(LogitMeanNode, MeanNode) is True
+    assert check_if_both_types_operators(LogitMeanNode, LogitMeanNode) is True

--- a/test/test_weighted_logit_mean_node.py
+++ b/test/test_weighted_logit_mean_node.py
@@ -1,0 +1,316 @@
+"""Unit tests for ``WeightedLogitMeanNode`` -- per-input weighting in *logit*
+space (the calibrated-stacking link), the natural join of ``LogitMeanNode``
+(global temperature on the mean logit) and ``WeightedMeanNode`` (per-input
+weights in probability space).
+
+These pin: the binary ``sigmoid(Sum w_i logit x_i)`` and multiclass weighted
+product maths; that equal weights ``t/K`` reproduce ``LogitMeanNode(t)`` exactly
+(the strict-superset claim); overflow safety; the GP hooks (create_node /
+mutate_params / copy / code); and -- specific to this node -- the *unnormalised*
+weight bookkeeping on add/remove/replace and the copy_subtree round-trip, plus an
+engine-evolution smoke test that the weight vector never desyncs from the children
+under real crossover + mutation.
+"""
+
+import numpy as np
+import pytest
+
+from okapi.globals import _passthrough, set_postprocessing_function
+from okapi.node import (
+    LogitMeanNode,
+    MeanNode,
+    ValueNode,
+    WeightedLogitMeanNode,
+    WeightedMeanNode,
+    check_if_both_types_operators,
+)
+from okapi.okapi import Okapi
+from okapi.operators import WEIGHTED_LOGIT_MEAN
+from okapi.pareto import maximize
+from okapi.tree import Tree
+
+
+@pytest.fixture(autouse=True)
+def _default_passthrough_postprocessing():
+    """The global postprocessing function is shared state; ensure the default
+    passthrough so the maths assertions hold regardless of test ordering."""
+    set_postprocessing_function(_passthrough)
+    yield
+    set_postprocessing_function(_passthrough)
+
+
+def _sigmoid(z):
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def _logit(p):
+    return np.log(p) - np.log(1.0 - p)
+
+
+def _identity(x):
+    return x
+
+
+def _acc(prediction, gt):
+    p = np.asarray(prediction)
+    y = np.asarray(gt).ravel().astype(int)
+    yhat = (p[:, 0] > 0.5).astype(int) if p.shape[1] == 1 else p.argmax(axis=1)
+    return float((yhat == y).mean())
+
+
+# ------------------------------- op() maths (binary) -------------------------------
+
+
+def test_binary_matches_weighted_logit_sum_reference():
+    rng = np.random.default_rng(0)
+    K = 3
+    x = rng.uniform(0.01, 0.99, size=(K, 7, 1))
+    w = [0.5, 1.5, 0.8]
+    out = WeightedLogitMeanNode(None, w).op(x)
+    ref = _sigmoid((np.array(w).reshape(K, 1, 1) * _logit(x)).sum(axis=0))
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+    assert out.shape == (7, 1)
+
+
+def test_equal_weights_t_over_K_recover_logit_mean_node():
+    # The strict-superset claim: all weights == t/K is exactly LogitMeanNode(t, 0).
+    rng = np.random.default_rng(3)
+    K = 4
+    x = rng.uniform(0.02, 0.98, size=(K, 6, 1))
+    t = 2.3
+    out = WeightedLogitMeanNode(None, [t / K] * K).op(x)
+    ref = LogitMeanNode(None, t, 0.0).op(x)
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+
+
+def test_idempotent_when_weights_sum_to_one_and_inputs_equal():
+    K = 4
+    x = np.full((K, 5, 1), 0.8)
+    out = WeightedLogitMeanNode(None, [1.0 / K] * K).op(x)
+    np.testing.assert_allclose(out, 0.8, atol=1e-9)
+    assert out.shape == (5, 1)
+
+
+def test_unit_weights_give_logit_sum_and_sharpen():
+    # weights all 1 -> Sum logit = K*logit for equal inputs -> more confident than the input
+    K, p = 3, 0.7
+    x = np.full((K, 1, 1), p)
+    out = WeightedLogitMeanNode(None, [1.0] * K).op(x).item()
+    ref = _sigmoid(K * _logit(np.array(p)))
+    assert out == pytest.approx(float(ref))
+    assert out > p
+
+
+@pytest.mark.parametrize("p", [0.0, 1.0])
+def test_binary_extremes_finite_and_in_unit_interval(p):
+    x = np.full((4, 3, 1), p)  # clipped internally -> no inf
+    out = WeightedLogitMeanNode(None, [2.0, 2.0, 2.0, 2.0]).op(x)
+    assert np.isfinite(out).all()
+    assert (out > 0).all() and (out < 1).all()
+
+
+def test_all_zero_weights_collapse_to_half_not_nan():
+    # Degenerate but legal (mutation can floor every weight at 0): Sum = 0 -> sigmoid(0).
+    x = np.full((3, 4, 1), 0.9)
+    out = WeightedLogitMeanNode(None, [0.0, 0.0, 0.0]).op(x)
+    assert np.isfinite(out).all()
+    np.testing.assert_allclose(out, 0.5, atol=1e-9)
+
+
+# ----------------------------- op() maths (multiclass) -----------------------------
+
+
+def test_multiclass_matches_weighted_product_prenorm():
+    rng = np.random.default_rng(2)
+    K = 3
+    x = rng.uniform(0.01, 0.99, size=(K, 5, 4))
+    x = x / x.sum(axis=-1, keepdims=True)
+    w = [0.7, 1.2, 0.5]
+    out = WeightedLogitMeanNode(None, w).op(x)
+    ref = np.exp((np.array(w).reshape(K, 1, 1) * np.log(x)).sum(axis=0))
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+    assert out.shape == (5, 4)
+    assert (out > 0).all()
+
+
+# --------------------------------- tree integration --------------------------------
+
+
+def test_in_tree_calculate_binary():
+    # A -> WLMN -> [C, D]; _concat stacks [A, C, D]; parent A is weight slot 0.
+    a = np.array([[0.6], [0.7]])
+    c = np.array([[0.8], [0.2]])
+    d = np.array([[0.5], [0.9]])
+    A = ValueNode(None, a, "A")
+    C = ValueNode(None, c, "C")
+    D = ValueNode(None, d, "D")
+    w = [0.9, 1.1, 0.7]
+    A.add_child(WeightedLogitMeanNode([C, D], w))
+
+    out = A.calculate()
+    stacked = np.stack([a, c, d], axis=0)
+    ref = _sigmoid((np.array(w).reshape(3, 1, 1) * _logit(stacked)).sum(axis=0))
+    np.testing.assert_allclose(out, ref, atol=1e-9)
+    assert out.shape == (2, 1)
+
+
+# ------------------------------------ GP plumbing ----------------------------------
+
+
+def test_create_node_positive_weights_correct_length_and_children():
+    c = ValueNode(None, np.zeros((2, 1)), "c")
+    node = WeightedLogitMeanNode.create_node([c])
+    assert isinstance(node, WeightedLogitMeanNode)
+    assert len(node._weights) == 2  # parent slot + one child
+    assert all(w > 0.0 for w in node._weights)
+    assert node.children == [c]
+    assert c.parent is node
+
+
+def test_mutate_params_returns_true_moves_and_stays_bounded():
+    np.random.seed(0)
+    node = WeightedLogitMeanNode(None, [1.0, 1.0, 1.0])
+    before = list(node._weights)
+    assert node.mutate_params() is True
+    assert node._weights != before
+    assert len(node._weights) == 3
+    for _ in range(300):
+        node.mutate_params(0.5)
+        assert len(node._weights) == 3
+        assert all(0.0 <= w <= 50.0 for w in node._weights)
+
+
+def test_copy_preserves_weights_and_detaches():
+    node = WeightedLogitMeanNode(None, [0.3, 1.7, 2.1])
+    cp = node.copy()
+    assert isinstance(cp, WeightedLogitMeanNode)
+    assert cp._weights == [0.3, 1.7, 2.1]
+    assert cp._weights is not node._weights  # independent list
+    assert cp.children == [] and cp.parent is None
+
+
+def test_code_reflects_weights_for_dedup():
+    assert WeightedLogitMeanNode(None, [1.0, 0.5]).code == "WLMN[1.0,0.5]"
+    # equal to one decimal -> identical code (deduplicated by Okapi.run_iteration)
+    assert WeightedLogitMeanNode(None, [1.04, 0.48]).code == WeightedLogitMeanNode(None, [0.96, 0.52]).code
+    # materially different weights -> different code
+    assert WeightedLogitMeanNode(None, [1.0, 0.5]).code != WeightedLogitMeanNode(None, [2.0, 0.5]).code
+
+
+def test_registered_as_operator_alias():
+    assert WEIGHTED_LOGIT_MEAN is WeightedLogitMeanNode
+
+
+def test_is_operator_for_crossover_typecheck():
+    assert check_if_both_types_operators(WeightedLogitMeanNode, MeanNode) is True
+    assert check_if_both_types_operators(WeightedLogitMeanNode, WeightedMeanNode) is True
+
+
+# ----------------------------- weight bookkeeping (structural) ----------------------
+
+
+def test_add_child_appends_free_weight_without_rescaling():
+    c1 = ValueNode(None, np.zeros((2, 1)), "c1")
+    node = WeightedLogitMeanNode([c1], [1.0, 0.5])  # parent, c1
+    c2 = ValueNode(None, np.zeros((2, 1)), "c2")
+    node.add_child(c2)
+    assert len(node.children) == 2
+    assert len(node._weights) == 3
+    assert node._weights[:2] == [1.0, 0.5]  # existing weights untouched (unnormalised)
+    assert node._weights[2] > 0.0
+
+
+def test_remove_child_pops_the_aligned_weight():
+    c1 = ValueNode(None, np.zeros((2, 1)), "c1")
+    c2 = ValueNode(None, np.zeros((2, 1)), "c2")
+    node = WeightedLogitMeanNode([c1, c2], [0.9, 0.3, 0.7])  # parent, c1, c2
+    node.remove_child(c1)  # c1 is slot 1
+    assert node.children == [c2]
+    assert node._weights == [0.9, 0.7]  # parent (slot 0) and c2's weight remain, aligned
+
+
+def test_length_assertion_fires_on_desync():
+    node = WeightedLogitMeanNode([ValueNode(None, np.zeros((2, 1)), "c")], [1.0, 0.5])
+    node._weights.append(0.3)  # deliberately desync
+    with pytest.raises(AssertionError):
+        node._weight_length_assertion()
+
+
+def test_copy_subtree_roundtrip_preserves_eval_and_length():
+    a = np.array([[0.6], [0.4]])
+    c = np.array([[0.7], [0.2]])
+    d = np.array([[0.3], [0.9]])
+    A = ValueNode(None, a, "A")
+    C = ValueNode(None, c, "C")
+    D = ValueNode(None, d, "D")
+    A.add_child(WeightedLogitMeanNode([C, D], [0.8, 1.2, 0.6]))
+    tree = Tree.create_tree_from_root(A)
+
+    out_orig = np.asarray(tree.evaluation)
+    copied = tree.copy()  # uses copy() ([] children + full weights) + copy_subtree re-attach
+    out_copy = np.asarray(copied.evaluation)
+    np.testing.assert_allclose(out_copy, out_orig, atol=1e-12)
+
+    op = copied.root.children[0]
+    assert isinstance(op, WeightedLogitMeanNode)
+    assert len(op._weights) == len(op.children) + 1 == 3
+
+
+# ------------------------------------ engine smoke ---------------------------------
+
+
+def test_engine_evolves_with_wlmn_without_weight_desync(tmp_path):
+    # Real crossover + structural mutation must keep every WLMN's weight vector in
+    # sync with its children (the bookkeeping above, exercised end-to-end).
+    rng = np.random.default_rng(0)
+    n_models = 8
+    fit_dir = tmp_path / "fit"
+    fit_dir.mkdir(parents=True)
+    for k in range(n_models):
+        np.save(fit_dir / f"m{k}.npy", rng.random((200, 1)).astype(np.float64))
+    gt_path = tmp_path / "gt.npy"
+    np.save(gt_path, (rng.random(200) > 0.5).astype(np.int64))
+
+    ok = Okapi(
+        preds_source=fit_dir,
+        gt_path=gt_path,
+        population_size=8,  # OKAPI seeds one tree per model, so must be <= n_models
+        population_multiplier=3,
+        tournament_size=4,
+        minimize_node_count=False,
+        objective_functions=(_acc,),
+        objectives=(maximize,),
+        allowed_ops=(MeanNode, WeightedLogitMeanNode),
+        backend="numpy",
+        seed=1,
+        postprocessing_function=_identity,
+    )
+
+    # Seed WLMN-bearing trees so crossover (copy_subtree) and structural mutation
+    # (append/prune children) actually manipulate WLMN weight vectors from gen 0.
+    # Any desync trips _weight_length_assertion mid-train and fails this test;
+    # surviving to the final Pareto front is not required (selection may cull them).
+    ids, models = ok.ids, ok.models
+    for _ in range(4):
+        pick = rng.choice(n_models, size=3, replace=False)
+        root = ValueNode(None, models[pick[0]], ids[pick[0]])
+        kids = [ValueNode(None, models[pick[1]], ids[pick[1]]),
+                ValueNode(None, models[pick[2]], ids[pick[2]])]
+        root.add_child(WeightedLogitMeanNode.create_node(kids))
+        ok.population.append(Tree.create_tree_from_root(root))
+    ok.population_size = len(ok.population)
+    ok.fitnesses = None
+
+    ok.train(25)
+
+    assert ok.population
+    for t in ok.population:
+        pred = np.asarray(t.predict())
+        assert np.isfinite(pred).all()
+        for n in t.nodes["op_nodes"]:
+            if isinstance(n, WeightedLogitMeanNode):
+                assert len(n._weights) == len(n.children) + 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/test_weighted_logit_mean_node.py
+++ b/test/test_weighted_logit_mean_node.py
@@ -154,6 +154,24 @@ def test_in_tree_calculate_binary():
     assert out.shape == (2, 1)
 
 
+@pytest.mark.parametrize("shape", [(5, 1), (4, 3), (4, 3, 2)])
+def test_calculate_streaming_matches_op_concat(shape):
+    rng = np.random.default_rng(10)
+    a = rng.uniform(0.01, 0.99, size=shape)
+    c = rng.uniform(0.01, 0.99, size=shape)
+    d = rng.uniform(0.01, 0.99, size=shape)
+    weights = [0.9, 1.1, 0.7]
+    node = WeightedLogitMeanNode(None, weights)
+    ref = node.op(np.stack([a, c, d], axis=0))
+
+    A = ValueNode(None, a, "A")
+    C = ValueNode(None, c, "C")
+    D = ValueNode(None, d, "D")
+    A.add_child(WeightedLogitMeanNode([C, D], weights))
+
+    np.testing.assert_allclose(A.calculate(), ref, atol=1e-9)
+
+
 # ------------------------------------ GP plumbing ----------------------------------
 
 


### PR DESCRIPTION
Distils the minimal, most-defensible subset of the recursive-improvement R&D
(`feature/advanced-fusion`) into `dev`. **Fix + caps + logit only** — everything
else (trust/meta/#30, k-fold CV, post-tune, guided seeding) stays on the research
branch, per the overnight ablation.

## What's in (5 commits)
- **Core search bug fix** (`get_random_node`) — the fix for the implicit depth-3 prior.
- **Depth/node caps** — C1 hard caps at generation time + deterministic legal-target
  selection + `Tree.depth`. This is the mechanism that makes the fix shippable:
  reproduces the historical compactness *by design* while restoring true random exploration.
  `max_depth`/`max_nodes` are tunables, **default `None` ⇒ backward-compatible**.
- **Logit-space operators** — `LogitMeanNode` + `WeightedLogitMeanNode`.

## Why this subset (overnight ablation, 10 scenarios × 4 degrades × 20 seeds)
- **Logit = the win**: baseline regret 0.0635 → logit 0.0480 (−24%) / wlogit 0.0464 (−27%);
  `all_on` no better than `wlogit` alone.
- **Trust/poison-detection = negative result** as a default lever (leave-one-out −0.0028:
  dropping it *improves* `all_on`); CV / post-tune / guided seeding are marginal-to-null.
- **Depth**: d3 = compact regime, d5 = accuracy knee; `max_depth` ships as a tunable default `None`.

## Provenance / safety
- Branched off `dev` (`08ba400`), which is tagged **`okapi-baseline-bugged`** so the exact
  engine the paper/thesis results were produced on stays reproducible.
- Full suite green (266 passed / 1 skipped), source ruff-clean, zero leakage of dropped features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)